### PR TITLE
Allow selectable ramdisk mountpoint location

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -28,12 +28,12 @@ pidfile="@lockfile@"
 user="nagios"
 group="nagios"
 checkconfig="false"
-ramdiskdir="/var/nagios/ramcache"
 
 test -e /etc/sysconfig/$prog && . /etc/sysconfig/$prog
 
 lockfile=/var/lock/subsys/$prog
 USE_RAMDISK=${USE_RAMDISK:-0}
+ramdiskdir=${RAMDISK_MOUNTPOINT:-/var/nagios/ramcache}
 
 if test "$USE_RAMDISK" -ne 0 && test "$RAMDISK_SIZE"X != "X"; then
 	ramdisk=`mount |grep "$ramdiskdir type tmpfs"`

--- a/nagios.sysconfig
+++ b/nagios.sysconfig
@@ -1,7 +1,10 @@
 # Setup some basic values for startup
 
-# Do you want to use the ramdisk
+# Do you want to use the ramdisk, this can speed up processing checkresults
 USE_RAMDISK=0
+
+# Where do you want the ramdisk mounted
+RAMDISK_MOUNTPOINT="/var/nagios/ramcache"
 
 # How big (in MB) should the ramdisk be
 RAMDISK_SIZE=256


### PR DESCRIPTION
It defaulted to /var/nagios/ramcache which doesn't flux well with some
platforms/distributions.
