### PR TITLE
Update deprecated attributes in sample config

### DIFF
--- a/sample-config/template-object/printer.cfg.in
+++ b/sample-config/template-object/printer.cfg.in
@@ -67,8 +67,8 @@ define service{
 	host_name		hplj2605dn		; The name of the host the service is associated with
 	service_description	Printer Status		; The service description
 	check_command		check_hpjd!-C public	; The command used to monitor the service
-	normal_check_interval	10	; Check the service every 10 minutes under normal conditions
-	retry_check_interval	1	; Re-check the service every minute until its final/hard state is determined
+	check_interval	        10	; Check the service every 10 minutes under normal conditions
+	retry_interval	        1	; Re-check the service every minute until its final/hard state is determined
 	}
 
 
@@ -79,6 +79,6 @@ define service{
 	host_name		hplj2605dn
 	service_description	PING
 	check_command		check_ping!3000.0,80%!5000.0,100%
-	normal_check_interval	10
-	retry_check_interval	1
+	check_interval	        10
+	retry_interval	        1
         }

--- a/sample-config/template-object/switch.cfg.in
+++ b/sample-config/template-object/switch.cfg.in
@@ -64,8 +64,8 @@ define service{
 	host_name		linksys-srw224p	; The name of the host the service is associated with
 	service_description	PING		; The service description
 	check_command		check_ping!200.0,20%!600.0,60%	; The command used to monitor the service
-	normal_check_interval	5		; Check the service every 5 minutes under normal conditions
-	retry_check_interval	1		; Re-check the service every minute until its final/hard state is determined
+	check_interval	        5		; Check the service every 5 minutes under normal conditions
+	retry_interval	        1		; Re-check the service every minute until its final/hard state is determined
 	}
 
 

--- a/sample-config/template-object/templates.cfg.in
+++ b/sample-config/template-object/templates.cfg.in
@@ -164,8 +164,8 @@ define service{
         is_volatile                     0       		; The service is not volatile
         check_period                    24x7			; The service can be checked at any time of the day
         max_check_attempts              3			; Re-check the service up to 3 times in order to determine its final (hard) state
-        normal_check_interval           10			; Check the service every 10 minutes under normal conditions
-        retry_check_interval            2			; Re-check the service every two minutes until a hard state can be determined
+        check_interval                  10			; Check the service every 10 minutes under normal conditions
+        retry_interval                  2			; Re-check the service every two minutes until a hard state can be determined
         contact_groups                  admins			; Notifications get sent out to everyone in the 'admins' group
 	notification_options		w,u,c,r			; Send notifications about warning, unknown, critical, and recovery events
         notification_interval           60			; Re-notify about service problems every hour
@@ -180,8 +180,8 @@ define service{
 	name				local-service 		; The name of this service template
 	use				generic-service		; Inherit default values from the generic-service definition
         max_check_attempts              4			; Re-check the service up to 4 times in order to determine its final (hard) state
-        normal_check_interval           5			; Check the service every 5 minutes under normal conditions
-        retry_check_interval            1			; Re-check the service every minute until a hard state can be determined
+        check_interval                  5			; Check the service every 5 minutes under normal conditions
+        retry_interval                  1			; Re-check the service every minute until a hard state can be determined
         register                        0       		; DONT REGISTER THIS DEFINITION - ITS NOT A REAL SERVICE, JUST A TEMPLATE!
 	}
 


### PR DESCRIPTION
- Changed normal_check_interval to check_interval
- Changed retry_check_interval to retry_interval

According to the documentation the old attribute names should
no longer exist, so switching to the newer documented behavior.

It should not change the behavior of a running environment, but it
can cause a lot of confusion when there is a mix of check_interval
and normal_check_interval in the same configuration object.

This has been a long time coming, but it has always been a thorn in my side that sample
configs use deprecated attribute names. Fresh start, better sample configs!
