### PR TITLE
Fix daemon_dumps_core on Linux when started as root

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -1814,6 +1814,12 @@ int drop_privileges(char *user, char *group) {
 		result = ERROR;
 	}
 
+#ifdef HAVE_SYS_PRCTL_H
+	/* on Linux the dumpable flag is cleared by system calls that manipulate process UIDs and GIDs */
+	if (daemon_dumps_core == TRUE)
+		prctl(PR_SET_DUMPABLE, 1);
+#endif
+
 	return result;
 	}
 

--- a/configure.in
+++ b/configure.in
@@ -29,7 +29,7 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_TIME
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(arpa/inet.h ctype.h dirent.h errno.h fcntl.h getopt.h grp.h libgen.h limits.h math.h netdb.h netinet/in.h pwd.h regex.h signal.h socket.h stdarg.h string.h strings.h sys/mman.h sys/types.h sys/time.h sys/resource.h sys/wait.h sys/socket.h sys/stat.h sys/timeb.h sys/un.h sys/ipc.h sys/msg.h sys/poll.h syslog.h uio.h unistd.h locale.h wchar.h)
+AC_CHECK_HEADERS(arpa/inet.h ctype.h dirent.h errno.h fcntl.h getopt.h grp.h libgen.h limits.h math.h netdb.h netinet/in.h pwd.h regex.h signal.h socket.h stdarg.h string.h strings.h sys/mman.h sys/types.h sys/time.h sys/resource.h sys/wait.h sys/socket.h sys/stat.h sys/timeb.h sys/un.h sys/ipc.h sys/msg.h sys/poll.h syslog.h uio.h unistd.h locale.h wchar.h sys/prctl.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -318,6 +318,10 @@
 #endif
 #endif
 
+#undef HAVE_SYS_PRCTL_H
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
 
 /* moved to end to prevent AIX compiler warnings */
 #ifndef RTLD_GLOBAL


### PR DESCRIPTION
Under Linux, systems calls that manipulate UIDs and GIDs reset the
process dumpable flag to 0. When Naemon is started as root it drops
privileges using setuid/setgid, preventing core dumps from being
produced regardless of the value of daemon_dumps_core. This patch fixes
that by calling prctl() in drop_privileges().

Signed-off-by: Adam James adam.james@transitiv.co.uk
