### PR TITLE
use "naemon.cfg" instead of "nagios.cfg"

### DIFF
--- a/naemon/config.c
+++ b/naemon/config.c
@@ -1181,7 +1181,7 @@ int read_main_config_file(char *main_config_file)
 	if (!temp_file) {
 		temp_file = nspath_absolute("nagios.tmp", temp_path);
 	} else if (*temp_file == '.') {
-		/* temp_file is relative. Make it nagios.cfg-relative */
+		/* temp_file is relative. Make it naemon.cfg-relative */
 		char *foo = temp_file;
 		temp_file = nspath_absolute(temp_file, config_file_dir);
 		free(foo);

--- a/naemon/naemon.c
+++ b/naemon/naemon.c
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
 		if (result != OK) {
 			printf("   Error processing object config files!\n\n");
 			/* if the config filename looks fishy, warn the user */
-			if (!strstr(config_file, "nagios.cfg")) {
+			if (!strstr(config_file, "naemon.cfg")) {
 				printf("\n***> The name of the main configuration file looks suspicious...\n");
 				printf("\n");
 				printf("     Make sure you are specifying the name of the MAIN configuration file on\n");

--- a/naemon/naemon.h
+++ b/naemon/naemon.h
@@ -446,7 +446,7 @@ extern int qh_register_handler(const char *name, const char *description, unsign
 extern const char *qh_strerror(int code);
 
 /**** Configuration Functions ****/
-int read_main_config_file(char *);                     		/* reads the main config file (nagios.cfg) */
+int read_main_config_file(char *);                     		/* reads the main config file (naemon.cfg) */
 int read_resource_file(char *);					/* processes macros in resource file */
 int read_all_object_data(char *);				/* reads all object config data */
 


### PR DESCRIPTION
fixes "name of main configuration file looks suspicious" if there's an
mistake in configuration. also changed comments.

Signed-off-by: Sven Velt sven@velt.de
