### PR TITLE
contrib/daemonchk.c: Fix for CVE-2013-7205

### DIFF
--- a/contrib/daemonchk.c
+++ b/contrib/daemonchk.c
@@ -174,7 +174,6 @@ static int process_cgivars(void) {
 
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
-			x++;
 			continue;
 			}
 		}


### PR DESCRIPTION
CVE-2013-7205 describes an ff-by-one error in the process_cgivars function in
contrib/daemonchk.c which affects several versions of nagios and icinga.

I might be a little out of my league in estimating what the impact is in
naemon, since it does not ship with the legacy cgis by default.

Information about the vulnerability can be found here:
http://www.cvedetails.com/cve/CVE-2013-7205/
