### PR TITLE
commands: Inspect correct option for passive host check acceptance

### DIFF
--- a/naemon/commands.c
+++ b/naemon/commands.c
@@ -2307,7 +2307,7 @@ int process_passive_host_check(time_t check_time, char *host_name, int return_co
 	struct timeval tv;
 
 	/* skip this host check result if we aren't accepting passive host checks */
-	if (accept_passive_service_checks == FALSE)
+	if (accept_passive_host_checks == FALSE)
 		return ERROR;
 
 	/* make sure we have all required data */


### PR DESCRIPTION
This patch fixes a bug where having passive service checks disabled
would not only disable passive service checks, but also implicitly
disable passive host checks.

You might think this would also have the effect of _not_ disabling
passive host checks (since we check the wrong option), but fortunately
we don't trust the command processing code and check the correct option
once we actually process the host check.

Signed-off-by: Anton Lofgren alofgren@op5.com
