### PR TITLE
checks: Refactor check output parsing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
-SUBDIRS = naemon
+SUBDIRS = naemon tests
+AM_CPPFLAGS = -I$(top_builddir)
 
 EXTRA_DIST = naemon.spec contrib
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_CONFIG_HEADERS([config.h naemon/lib/snprintf.h])
 AC_PREFIX_DEFAULT(/usr/local/naemon)
 
 # Checks for programs.
+AM_PATH_CHECK([0.9.0], [], [AC_MSG_ERROR([check is missing])])
 AC_PROG_CC
 AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
@@ -156,6 +157,7 @@ AC_CONFIG_FILES([Makefile
                  naemon/Makefile
                  naemon/defaults.h
                  naemon/lib/Makefile
+				 tests/Makefile
                  sample-config/naemon.cfg
                  sample-config/resource.cfg
                  sample-config/conf.d/commands.cfg

--- a/naemon/checks.h
+++ b/naemon/checks.h
@@ -23,6 +23,7 @@
 NAGIOS_BEGIN_DECL
 
 int parse_check_output(char *, char **, char **, char **, int, int);
+struct check_output *parse_output(const char *, struct check_output *);
 int check_service_dependencies(service *, int);          	/* checks service dependencies */
 int check_host_dependencies(host *, int);                	/* checks host dependencies */
 void check_for_orphaned_services(void);				/* checks for orphaned services */

--- a/naemon/objects.h
+++ b/naemon/objects.h
@@ -120,6 +120,12 @@ struct check_engine {
 	void (*clean_result)(void *);
 };
 
+struct check_output {
+	char *short_output;
+	char *long_output;
+	char *perf_data;
+};
+
 /* CHECK_RESULT structure */
 typedef struct check_result {
 	int object_check_type;                          /* is this a service or a host check? */

--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -89,12 +89,51 @@ void setup_objects(time_t time)
 
 }
 
+#defined FREE_OUTPUT() free(output; free(short_output); free(long_output); free(perf_data);
+void
+test_parse_check_output() {
+	/**
+	 * TEXT OUTPUT | OPTIONAL PERFDATA
+	 * LONG TEXT LINE 1
+	 * LONG TEXT LINE 2
+	 * ...
+	 * LONG TEXT LINE N | PERFDATA LINE 2
+	 * PERFDATA LINE 3
+	 * ...
+	 * PERFDATA LINE N
+	 **/
+	char *full_output = "TEST OK - just one line of output, no perfdata";
+	char *output = strdup(full_output);
+	char *short_output = NULL, *long_output = NULL, *perf_data = NULL;
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ok(0 == strcmp(short_output, full_output), "short output contains all of the output") || diag("short output was: '%s', compare with full output '%s'", short_output, full_output);
+	ok(NULL == long_output, "there is no long output");
+	ok(NULL == long_output, "there is no perfdata");
+	FREE_OUTPUT()
+
+	full_output = "TEST WARNING - a line of output and | some=perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ok(0 == strcmp(short_output, "TEST WARNING - a line of output and"), "short output contains the initial text output") || diag("short output was: '%s', compare with full output '%s'", short_output, full_output);
+	ok(0 == strcmp(perf_data, "some=perfdata;"), "perfdata looks correct") || diag("perfdata was: '%s', compare with full output '%s'", perf_data, full_output);
+	ok(NULL == long_output, "there is no long output");
+	FREE_OUTPUT()
+
+	full_output = "TEST OK - a line of output and | some=perfdata;\nHere's some additional\nLONG output\nwhich suddenly becomes | more=perfdata;\non=several;lines;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ok(0 == strcmp(short_output, "TEST OK - a line of output and"), "short output contains the initial text output") || diag("short output was: '%s', compare with full output '%s'", short_output, full_output);
+	ok(0 == strcmp(perf_data, "some=perfdata; more=perfdata; on=several;lines;"), "perfdata looks correct") || diag("perfdata was: '%s', compare with full output '%s'", perf_data, full_output);
+	ok(0 == strcmp(long_output, "Here's some additional\nLONG output\nwhich suddenly becomes "), "long output looks correct") || diag("long output was: '%s', compare with full output '%s'", long_output, full_output);
+	FREE_OUTPUT()
+}
+
 int main(int argc, char **argv)
 {
 	time_t now = 0L;
 
 
-	plan_tests(35);
+	plan_tests(44);
 
 	time(&now);
 
@@ -359,6 +398,7 @@ int main(int argc, char **argv)
 	ok(host1->current_attempt == 1, "Attempts reset") || diag("current_attempt=%d", host1->current_attempt);
 	ok(strcmp(host1->plugin_output, "UP again") == 0, "output set") || diag("plugin_output=%s", host1->plugin_output);
 
+	test_parse_check_output();
 
 	return exit_status();
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,8 @@
+TESTS = test-checks
+TEST_CHECKS_DEPS = nebmods.o commands.o broker.o query-handler.o utils.o events.o notifications.o \
+			  flapping.o sehandlers.o logging.o workers.o shared.o comments.o downtime.o sretention.o objects.o \
+			  macros.o statusdata.o xcddefault.o xrddefault.o xsddefault.o xpddefault.o perfdata.o xodtemplate.o
+test_checks_SOURCES	= test-checks.c $(top_builddir)/naemon/checks.h $(top_builddir)/naemon/checks.c
+test_checks_CFLAGS = @CHECK_CFLAGS@
+test_checks_LDADD =  $(TEST_CHECKS_DEPS:%=$(top_builddir)/naemon/naemon-%) @CHECK_LIBS@ $(top_builddir)/naemon/lib/libnaemon.la -lm -ldl
+check_PROGRAMS = $(TESTS)

--- a/tests/test-checks.c
+++ b/tests/test-checks.c
@@ -1,0 +1,150 @@
+#include <check.h>
+#include "naemon/checks.h"
+
+char *full_output;
+char *short_output;
+char *long_output;
+char *perf_data;
+char *output;
+
+void setup (void) {
+	short_output = NULL;
+	long_output = NULL;
+	perf_data = NULL;
+	full_output = NULL;
+	output = NULL;
+}
+void teardown (void) {
+	free(output);
+	free(short_output);
+	free(long_output);
+	free(perf_data);
+	free(full_output);
+}
+
+START_TEST(one_line_no_perfdata)
+{
+	full_output = "TEST OK - just one line of output, no perfdata";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq(short_output, full_output);
+	ck_assert_ptr_eq(NULL, long_output);
+	ck_assert_ptr_eq(NULL, perf_data);
+
+}
+END_TEST
+
+START_TEST(one_line_with_perfdata)
+{
+	full_output = "TEST WARNING - a line of output and | some=perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq("TEST WARNING - a line of output and", short_output);
+	ck_assert_str_eq("some=perfdata;", perf_data);
+	ck_assert_ptr_eq(NULL, long_output);
+}
+END_TEST
+
+START_TEST(multiple_line_output_no_perfdata)
+{
+	full_output = "TEST WARNING - first a line of output\n"
+				  "and then some more output on another line";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq("TEST WARNING - first a line of output", short_output);
+	ck_assert_str_eq("and then some more output on another line", long_output);
+	ck_assert_ptr_eq(NULL, perf_data);
+}
+END_TEST
+
+START_TEST(multiple_line_output_and_multiple_line_perfdata)
+{
+	full_output = "TEST OK - a line of output and | some=perfdata;\n"
+		"Here's some additional\n"
+		"LONG output\n"
+		"which suddenly becomes | more=perfdata;\n"
+		"on=several;lines;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq("TEST OK - a line of output and", short_output);
+	ck_assert_str_eq("Here's some additional\nLONG output\nwhich suddenly becomes ", long_output );
+	ck_assert_str_eq("some=perfdata; more=perfdata; on=several;lines;", perf_data);
+
+}
+END_TEST
+
+START_TEST(multiple_line_output_and_perfdata_but_not_on_first_line)
+{
+	full_output = "TEST CRITICAL - Oh my\n"
+				  "Here's a second line of output and | some=perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq("TEST CRITICAL - Oh my", short_output);
+	ck_assert_str_eq("some=perfdata;", perf_data);
+	ck_assert_str_eq("Here's a second line of output and ", long_output);
+}
+END_TEST
+
+START_TEST(one_line_output_and_perfdata_but_not_on_first_line)
+{
+	full_output = "TEST CRITICAL - Oh my\n| some=perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_str_eq("TEST CRITICAL - Oh my", short_output);
+	ck_assert_ptr_eq(NULL, long_output);
+	ck_assert_str_eq("some=perfdata;", perf_data);
+}
+END_TEST
+
+START_TEST(perfdata_only)
+{
+	full_output = "| some=perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_ptr_eq(NULL, short_output);
+	ck_assert_ptr_eq(NULL, long_output);
+	ck_assert_str_eq("some=perfdata;", perf_data);
+}
+END_TEST
+
+
+START_TEST(multiline_perfdata_only)
+{
+	full_output = "| some=perfdata;\n"
+				  "|and=more;perfdata;";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, FALSE, FALSE);
+	ck_assert_ptr_eq(NULL, short_output);
+	ck_assert_ptr_eq(NULL, long_output);
+	ck_assert_str_eq("some=perfdata; and=more;perfdata;", perf_data);
+}
+END_TEST
+
+Suite*
+checks_suite(void)
+{
+	Suite *s = suite_create("Checks");
+	TCase *tc_output = tcase_create("Output parsing");
+	tcase_add_unchecked_fixture(tc_output, setup, teardown);
+	tcase_add_test(tc_output, one_line_no_perfdata);
+	tcase_add_test(tc_output, one_line_with_perfdata);
+	tcase_add_test(tc_output, multiple_line_output_no_perfdata);
+	tcase_add_test(tc_output, multiple_line_output_and_multiple_line_perfdata);
+	tcase_add_test(tc_output, multiple_line_output_and_perfdata_but_not_on_first_line);
+	tcase_add_test(tc_output, one_line_output_and_perfdata_but_not_on_first_line);
+	tcase_add_test(tc_output, perfdata_only);
+	tcase_add_test(tc_output, multiline_perfdata_only);
+	suite_add_tcase(s, tc_output);
+	return s;
+}
+
+int main(void)
+{
+	int number_failed = 0;
+	Suite *s = checks_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
The check output/perfdata parsing is needlessly contrived (and
inefficient, though that is secondary.) This patch adds a cleaner
alternative interface to output parsing, makes better use of available
data structures and, presumably, improves performance. It also (imo)
makes the code a bit easier to follow.

Both ABI and API are preserved, through the parse_check_output function.

I've added tests as well, though those are not currently runnable, as
per GH issue #12.

Signed-off-by: Anton Lofgren alofgren@op5.com
