### PR TITLE
checks: Be consistent in handling missing output

### DIFF
--- a/naemon/checks.c
+++ b/naemon/checks.c
@@ -2190,8 +2190,7 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 	parse_check_output(queued_check_result->output, &temp_host->plugin_output, &temp_host->long_plugin_output, &temp_host->perf_data, TRUE, FALSE);
 
 	/* make sure we have some data */
-	if (temp_host->plugin_output == NULL || !strcmp(temp_host->plugin_output, "")) {
-		my_free(temp_host->plugin_output);
+	if (temp_host->plugin_output == NULL) {
 		temp_host->plugin_output = (char *)strdup("(No output returned from host check)");
 	}
 


### PR DESCRIPTION
For service checks, we let the plugin_output be "(No output returned
from the plugin)" in case we get _no_(NULL) short output. For host
checks, this is also done when the output is empty("")(albeit with the
string "(No output returned from host check)" instead).

This patch changes the behaviour for host checks, so that we only
replace the output if it is NULL, since this signifies a fault.

If the output is an empty string, this is likely the intended - though,
one could argue, misdirected - behaviour by the plugin author, and I
don't think it's appropriate that we mess around with it.

Signed-off-by: Anton Lofgren alofgren@op5.com
