### PR TITLE
Remove "extern" from method prototypes

### DIFF
--- a/naemon/common.h
+++ b/naemon/common.h
@@ -48,7 +48,7 @@ extern char *config_file_dir;
 
 #ifdef HAVE_TZNAME
 #ifdef CYGWIN
-extern char     *_tzname[2] __declspec(dllimport);
+char     *_tzname[2] __declspec(dllimport);
 #else
 extern char     *tzname[2];
 #endif
@@ -335,7 +335,7 @@ NAGIOS_END_DECL
 #define CMD_ERROR_INTERNAL_ERROR 3 /* Internal error */
 #define CMD_ERROR_FAILURE 4 /* Command routine failed */
 
-extern const char *cmd_error_strerror(int error_code);
+const char *cmd_error_strerror(int error_code);
 
 /**************************** CHECK TYPES ********************************/
 

--- a/naemon/macros.h
+++ b/naemon/macros.h
@@ -263,7 +263,7 @@ int init_macros(void);
 int init_macrox_names(void);
 int free_macrox_names(void);
 
-extern void copy_constant_macros(char **dest);
+void copy_constant_macros(char **dest);
 
 /* clear macros */
 int clear_argv_macros(void);

--- a/naemon/nerd.h
+++ b/naemon/nerd.h
@@ -11,12 +11,12 @@ struct nerd_subscription {
 };
 
 /*** Nagios Event Radio Dispatcher functions ***/
-extern int nerd_init(void);
-extern int nerd_mkchan(const char *name, const char *description, int (*handler)(int, void *), unsigned int callbacks);
-extern int nerd_cancel_subscriber(int sd);
-extern int nerd_get_channel_id(const char *chan_name);
-extern objectlist *nerd_get_subscriptions(int chan_id);
-extern int nerd_broadcast(unsigned int chan_id, void *buf, unsigned int len);
+int nerd_init(void);
+int nerd_mkchan(const char *name, const char *description, int (*handler)(int, void *), unsigned int callbacks);
+int nerd_cancel_subscriber(int sd);
+int nerd_get_channel_id(const char *chan_name);
+objectlist *nerd_get_subscriptions(int chan_id);
+int nerd_broadcast(unsigned int chan_id, void *buf, unsigned int len);
 
 NAGIOS_END_DECL
 

--- a/naemon/objects.h
+++ b/naemon/objects.h
@@ -695,10 +695,10 @@ extern struct servicedependency **servicedependency_ary;
 
 
 /* silly helpers useful pretty much all over the place */
-extern const char *service_state_name(int state);
-extern const char *host_state_name(int state);
-extern const char *state_type_name(int state_type);
-extern const char *check_type_name(int check_type);
+const char *service_state_name(int state);
+const char *host_state_name(int state);
+const char *state_type_name(int state_type);
+const char *check_type_name(int check_type);
 
 /**** Top-level input functions ****/
 int read_object_config_data(const char *, int);     /* reads all external configuration data of specific types */

--- a/naemon/query-handler.h
+++ b/naemon/query-handler.h
@@ -13,10 +13,10 @@ NAGIOS_BEGIN_DECL
 /*** Query Handler functions, types and macros*/
 typedef int (*qh_handler)(int, char *, unsigned int);
 
-extern int qh_init(const char *path);
-extern void qh_deinit(const char *path);
-extern int qh_register_handler(const char *name, const char *description, unsigned int options, qh_handler handler);
-extern const char *qh_strerror(int code);
+int qh_init(const char *path);
+void qh_deinit(const char *path);
+int qh_register_handler(const char *name, const char *description, unsigned int options, qh_handler handler);
+const char *qh_strerror(int code);
 
 NAGIOS_END_DECL
 

--- a/naemon/shared.h
+++ b/naemon/shared.h
@@ -35,20 +35,20 @@ struct object_count {
 
 extern struct object_count num_objects;
 
-extern void timing_point(const char *fmt, ...); /* print a message and the time since the first message */
-extern char *my_strtok(char *buffer, const char *tokens);
-extern char *my_strsep(char **stringp, const char *delim);
-extern mmapfile *mmap_fopen(const char *filename);
-extern int mmap_fclose(mmapfile *temp_mmapfile);
-extern char *mmap_fgets(mmapfile *temp_mmapfile);
-extern char *mmap_fgets_multiline(mmapfile * temp_mmapfile);
-extern void strip(char *buffer);
-extern int hashfunc(const char *name1, const char *name2, int hashslots);
-extern int compare_hashdata(const char *val1a, const char *val1b, const char *val2a,
+void timing_point(const char *fmt, ...); /* print a message and the time since the first message */
+char *my_strtok(char *buffer, const char *tokens);
+char *my_strsep(char **stringp, const char *delim);
+mmapfile *mmap_fopen(const char *filename);
+int mmap_fclose(mmapfile *temp_mmapfile);
+char *mmap_fgets(mmapfile *temp_mmapfile);
+char *mmap_fgets_multiline(mmapfile * temp_mmapfile);
+void strip(char *buffer);
+int hashfunc(const char *name1, const char *name2, int hashslots);
+int compare_hashdata(const char *val1a, const char *val1b, const char *val2a,
                             const char *val2b);
-extern void get_datetime_string(time_t *raw_time, char *buffer,
+void get_datetime_string(time_t *raw_time, char *buffer,
                                 int buffer_length, int type);
-extern void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
+void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
                                int *minutes, int *seconds);
 
 NAGIOS_END_DECL

--- a/naemon/utils.h
+++ b/naemon/utils.h
@@ -12,7 +12,7 @@ int set_loadctl_options(char *opts, unsigned int len);
 
 void setup_sighandler(void);                         		/* trap signals */
 void reset_sighandler(void);                         		/* reset signals to default action */
-extern void handle_sigxfsz(int);				/* handle SIGXFSZ */
+void handle_sigxfsz(int);				/* handle SIGXFSZ */
 int daemon_init(void);				     		/* switches to daemon mode */
 int drop_privileges(char *, char *);				/* drops privileges before startup */
 

--- a/naemon/workers.h
+++ b/naemon/workers.h
@@ -47,17 +47,17 @@ extern unsigned int wproc_num_workers_desired;
 
 struct load_control; /* TODO: load_control is ugly */
 
-extern void wproc_reap(int jobs, int msecs);
-extern int wproc_can_spawn(struct load_control *lc);
-extern void free_worker_memory(int flags);
-extern int workers_alive(void);
-extern int init_workers(int desired_workers);
-extern int wproc_run_check(check_result *cr, char *cmd, nagios_macros *mac);
-extern int wproc_notify(char *cname, char *hname, char *sdesc, char *cmd, nagios_macros *mac);
-extern int wproc_run(int job_type, char *cmd, int timeout, nagios_macros *mac);
-extern int wproc_run_service_job(int jtype, int timeout, service *svc, char *cmd, nagios_macros *mac);
-extern int wproc_run_host_job(int jtype, int timeout, host *hst, char *cmd, nagios_macros *mac);
-extern int wproc_run_callback(char *cmt, int timeout, void (*cb)(struct wproc_result *, void *, int), void *data, nagios_macros *mac);
+void wproc_reap(int jobs, int msecs);
+int wproc_can_spawn(struct load_control *lc);
+void free_worker_memory(int flags);
+int workers_alive(void);
+int init_workers(int desired_workers);
+int wproc_run_check(check_result *cr, char *cmd, nagios_macros *mac);
+int wproc_notify(char *cname, char *hname, char *sdesc, char *cmd, nagios_macros *mac);
+int wproc_run(int job_type, char *cmd, int timeout, nagios_macros *mac);
+int wproc_run_service_job(int jtype, int timeout, service *svc, char *cmd, nagios_macros *mac);
+int wproc_run_host_job(int jtype, int timeout, host *hst, char *cmd, nagios_macros *mac);
+int wproc_run_callback(char *cmt, int timeout, void (*cb)(struct wproc_result *, void *, int), void *data, nagios_macros *mac);
 
 NAGIOS_END_DECL;
 #endif


### PR DESCRIPTION
extern is the default behaviour for method prototypes that isn't
declrared as static. Explicitly specify extern in the header files just
adds to the noise for the person reading the header files.

Signed-off-by: Max Sikstrom msikstrom@op5.com
