### PR TITLE
Re-enable checks for initgroups() and unsetenv()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,8 +123,8 @@ AC_FUNC_WAIT3
 # Don't add functions to this list that are in either C89 or in
 # both POSIX.1-2001 and C99. Just let the compile fail instead.
 # Also, obviously, don't add functions that aren't used in the code.
-AC_CHECK_FUNCS([dup2 floor ftruncate munmap pow putenv realpath \
-	regcomp select setenv strncasecmp strrchr tzset])
+AC_CHECK_FUNCS([dup2 floor ftruncate initgroups munmap pow putenv realpath \
+	regcomp select setenv strncasecmp strrchr tzset unsetenv])
 
 # Determine the system init.d directory
 AC_ARG_WITH([initdir],


### PR DESCRIPTION
7b7c13c4420da1231bb300215630b03588766b2c accidentally removed
configure-time checks for initgroups() and unsetenv() availability,
essentially generating dead code due to HAVE_\* checks and introducing
issues with dropping permissions. This patch simply restores those
checks.
