### PR TITLE
building: Invoke `missing' on missing help2man

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ AM_CONDITIONAL([HAVE_CHECK], [test "x$with_tests" = "xyes"])
 
 AM_MISSING_PROG([PROVE], [prove])
 AM_MISSING_PROG([GPERF], [gperf])
+AM_MISSING_PROG(HELP2MAN, help2man)
 # am_missing_prog doesn't seem to fail,
 # so I'm putting this redundant check in place to whine more loudly:
 AC_CHECK_PROG(GPERF_CHECK,gperf,yes)

--- a/naemon/Makefile.am
+++ b/naemon/Makefile.am
@@ -103,10 +103,10 @@ distclean-local:
 	rm -rf Makefile.in
 
 manpages: naemon naemonstats shadownaemon oconfsplit
-	help2man --no-info --section=8 --help-option=-h -n "monitoring core"                          ./naemon       > naemon.8
-	help2man --no-info --section=8 --help-option=-h -n "gather statistics from naemon core"       ./naemonstats  > naemonstats.8
-	help2man --no-info --section=8 --help-option=-h -n "shadow remote cores via livestatus"       ./shadownaemon > shadownaemon.8
-	help2man --no-info --section=8 --help-option=-h -n "split naemon configuration by hostgroups" ./oconfsplit   > oconfsplit.8
+	$(HELP2MAN) --no-info --section=8 --help-option=-h -n "monitoring core"                          ./naemon       > naemon.8
+	$(HELP2MAN) --no-info --section=8 --help-option=-h -n "gather statistics from naemon core"       ./naemonstats  > naemonstats.8
+	$(HELP2MAN) --no-info --section=8 --help-option=-h -n "shadow remote cores via livestatus"       ./shadownaemon > shadownaemon.8
+	$(HELP2MAN) --no-info --section=8 --help-option=-h -n "split naemon configuration by hostgroups" ./oconfsplit   > oconfsplit.8
 
 install-data-local:
 	mkdir -p $(DESTDIR)$(mandir)/man8/


### PR DESCRIPTION
This gives the standard `missing' blurb for help2man if someone tries to
build manpages without having help2man installed, which is better (as
in, more helpful) than "help2man: command not found", in my opinion.

Signed-off-by: Anton Lofgren alofgren@op5.com
