### PR TITLE
Warnings are not relevant for starting naemon

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -62,10 +62,9 @@ pidof_naemon() {
 check_config() {
     TMPFILE=$(mktemp /tmp/.configtest.XXXXXXXX)
     $0 configtest > "$TMPFILE"
-    WARN=`grep ^"Total Warnings:" "$TMPFILE" |awk -F: '{print \$2}' |sed s/' '//g`
     ERR=`grep ^"Total Errors:" "$TMPFILE" |awk -F: '{print \$2}' |sed s/' '//g`
 
-    if test "$WARN" = "0" && test "${ERR}" = "0"; then
+    if test "${ERR}" = "0"; then
         echo "OK - Configuration check verified" > @TMPDIR@/naemon.configtest
         chmod 0644 @TMPDIR@/naemon.configtest
         /bin/rm "$TMPFILE"
@@ -73,7 +72,7 @@ check_config() {
     else
         # We'll write out the errors to a file we can have a
         # script watching for
-        echo "WARNING: Errors in config files - see log for details: $TMPFILE" > @TMPDIR@/naemon.configtest
+        echo "ERROR: Errors in config files - see log for details: $TMPFILE" > @TMPDIR@/naemon.configtest
         egrep -i "(^warning|^error)" "$TMPFILE" >> @TMPDIR@/naemon.configtest
         chmod 0644 @TMPDIR@/naemon.configtest
         cat "$TMPFILE"


### PR DESCRIPTION
naemon can start just fine with warnings, so don't let the init script bail out.
Otherwise people will see that naemon doesn't start, but the logfile says everything is ok with warnings ...
