### PR TITLE
commands: Always NUL terminate command buffer

### DIFF
--- a/naemon/commands.c
+++ b/naemon/commands.c
@@ -145,9 +145,9 @@ static int command_input_handler(int sd, int events, void *discard)
 		return 0;
 	}
 	while ((buf = iocache_use_delim(command_worker.ioc, "\n", 1, &size))) {
+		buf[size] = 0;
 		if (buf[0] == '[') {
 			/* raw external command */
-			buf[size] = 0;
 			log_debug_info(DEBUGL_COMMANDS, 1, "Read raw external command '%s'\n", buf);
 		}
 		if ((cmd_ret = process_external_command1(buf)) != CMD_ERROR_OK) {


### PR DESCRIPTION
Since we pass the buffer to the process_external_command1() routine
regardless of whether it seems well-formed or not, we better terminate
it regardless as well. If we don't, we're going to overread the buffer
sooner or later, causing not only this but also subsequent commands to
become garbled.

This fixes op5#8682.

Signed-off-by: Anton Lofgren alofgren@op5.com
