### PR TITLE
Abort when memory allocation fails

### DIFF
--- a/naemon/Makefile.am
+++ b/naemon/Makefile.am
@@ -21,7 +21,7 @@ pkginclude_HEADERS = \
 	configuration.h  macros.h       nebstructs.h     sretention.h \
 	defaults.h       naemon.h       nerd.h           statusdata.h \
 	downtime.h       naemonstats.h  notifications.h  utils.h \
-	buildopts.h
+	buildopts.h      nm_alloc.h
 
 all-local: manpages
 
@@ -60,6 +60,7 @@ common_sources = \
 	nebmods.c nebmods.h \
 	nebmodules.h nebstructs.h \
 	nerd.c nerd.h \
+	nm_alloc.c nm_alloc.h \
 	notifications.c notifications.h \
 	objects.c objects.h \
 	perfdata.c perfdata.h \

--- a/naemon/broker.c
+++ b/naemon/broker.c
@@ -8,6 +8,7 @@
 #include "notifications.h"
 #include "sehandlers.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 #ifdef USE_EVENT_BROKER
@@ -145,7 +146,7 @@ int broker_event_handler(int type, int flags, int attr, int eventhandler_type, v
 
 	/* get command name/args */
 	if (cmd != NULL) {
-		command_buf = (char *)strdup(cmd);
+		command_buf = nm_strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
 	}
@@ -207,7 +208,7 @@ int broker_host_check(int type, int flags, int attr, host *hst, int check_type, 
 
 	/* get command name/args */
 	if (cmd != NULL) {
-		command_buf = (char *)strdup(cmd);
+		command_buf = nm_strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
 	}
@@ -267,7 +268,7 @@ int broker_service_check(int type, int flags, int attr, service *svc, int check_
 
 	/* get command name/args */
 	if (cmd != NULL) {
-		command_buf = (char *)strdup(cmd);
+		command_buf = nm_strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
 	}
@@ -644,7 +645,7 @@ int broker_contact_notification_method_data(int type, int flags, int attr, int n
 
 	/* get command name/args */
 	if (cmd != NULL) {
-		command_buf = (char *)strdup(cmd);
+		command_buf = nm_strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
 	}

--- a/naemon/comments.c
+++ b/naemon/comments.c
@@ -6,6 +6,7 @@
 #include "broker.h"
 #include "events.h"
 #include "globals.h"
+#include "nm_alloc.h"
 
 comment *comment_list = NULL;
 int defer_comment_sorting = 0;
@@ -340,9 +341,7 @@ int add_comment_to_hashlist(comment *new_comment)
 	if (comment_hashlist == NULL) {
 		int i;
 
-		comment_hashlist = (comment **)malloc(sizeof(comment *) * COMMENT_HASHSLOTS);
-		if (comment_hashlist == NULL)
-			return 0;
+		comment_hashlist = nm_malloc(sizeof(comment *) * COMMENT_HASHSLOTS);
 
 		for (i = 0; i < COMMENT_HASHSLOTS; i++)
 			comment_hashlist[i] = NULL;
@@ -409,20 +408,15 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 		return ERROR;
 
 	/* allocate memory for the comment */
-	if ((new_comment = (comment *)calloc(1, sizeof(comment))) == NULL)
-		return ERROR;
+	new_comment = nm_calloc(1, sizeof(comment));
 
 	/* duplicate vars */
-	if ((new_comment->host_name = (char *)strdup(host_name)) == NULL)
-		result = ERROR;
+	new_comment->host_name = nm_strdup(host_name);
 	if (comment_type == SERVICE_COMMENT) {
-		if ((new_comment->service_description = (char *)strdup(svc_description)) == NULL)
-			result = ERROR;
+		new_comment->service_description = nm_strdup(svc_description);
 	}
-	if ((new_comment->author = (char *)strdup(author)) == NULL)
-		result = ERROR;
-	if ((new_comment->comment_data = (char *)strdup(comment_data)) == NULL)
-		result = ERROR;
+	new_comment->author = nm_strdup(author);
+	new_comment->comment_data = nm_strdup(comment_data);
 
 	new_comment->comment_type = comment_type;
 	new_comment->entry_type = entry_type;
@@ -510,8 +504,7 @@ int sort_comments(void)
 	if (!unsorted_comments)
 		return OK;
 
-	if (!(array = malloc(sizeof(*array) * unsorted_comments)))
-		return ERROR;
+	array = nm_malloc(sizeof(*array) * unsorted_comments);
 	while (comment_list) {
 		array[i++] = comment_list;
 		comment_list = comment_list->next;

--- a/naemon/configuration.c
+++ b/naemon/configuration.c
@@ -10,6 +10,7 @@
 #include "events.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <sys/types.h>
 #include <dirent.h>
 #include <string.h>
@@ -40,10 +41,8 @@ static objectlist *deprecated = NULL;
 static void obsoleted_warning(const char *key, const char *msg)
 {
 	char *buf;
-	asprintf(&buf, "Warning: %s is deprecated and will be removed.%s%s\n",
+	nm_asprintf(&buf, "Warning: %s is deprecated and will be removed.%s%s\n",
 	         key, msg ? " " : "", msg ? msg : "");
-	if (!buf)
-		return;
 	prepend_object_to_objectlist(&deprecated, buf);
 }
 
@@ -76,7 +75,7 @@ int read_main_config_file(const char *main_config_file)
 
 	/* save the main config file macro */
 	my_free(mac->x[MACRO_MAINCONFIGFILE]);
-	if ((mac->x[MACRO_MAINCONFIGFILE] = (char *)strdup(main_config_file)))
+	if ((mac->x[MACRO_MAINCONFIGFILE] = nm_strdup(main_config_file)))
 		strip(mac->x[MACRO_MAINCONFIGFILE]);
 
 	/* process all lines in the config file */
@@ -101,27 +100,19 @@ int read_main_config_file(const char *main_config_file)
 
 		/* get the variable name */
 		if ((temp_ptr = my_strtok(input, "=")) == NULL) {
-			asprintf(&error_message, "NULL variable");
+			nm_asprintf(&error_message, "NULL variable");
 			error = TRUE;
 			break;
 		}
-		if ((variable = (char *)strdup(temp_ptr)) == NULL) {
-			asprintf(&error_message, "malloc() error");
-			error = TRUE;
-			break;
-		}
+		variable = nm_strdup(temp_ptr);
 
 		/* get the value */
 		if ((temp_ptr = my_strtok(NULL, "\n")) == NULL) {
-			asprintf(&error_message, "NULL value");
+			nm_asprintf(&error_message, "NULL value");
 			error = TRUE;
 			break;
 		}
-		if ((value = (char *)strdup(temp_ptr)) == NULL) {
-			asprintf(&error_message, "malloc() error");
-			error = TRUE;
-			break;
-		}
+		value = (char *)nm_strdup(temp_ptr);
 		strip(variable);
 		strip(value);
 
@@ -149,7 +140,7 @@ int read_main_config_file(const char *main_config_file)
 		} else if (!strcmp(variable, "log_file")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Log file is too long");
+				nm_asprintf(&error_message, "Log file is too long");
 				error = TRUE;
 				break;
 			}
@@ -167,7 +158,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "debug_file")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Debug log file is too long");
+				nm_asprintf(&error_message, "Debug log file is too long");
 				error = TRUE;
 				break;
 			}
@@ -182,7 +173,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "command_file")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Command file is too long");
+				nm_asprintf(&error_message, "Command file is too long");
 				error = TRUE;
 				break;
 			}
@@ -196,7 +187,7 @@ int read_main_config_file(const char *main_config_file)
 
 		else if (!strcmp(variable, "temp_file")) {
 			my_free(temp_file);
-			temp_file = strdup(value);
+			temp_file = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "temp_path")) {
@@ -207,7 +198,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_result_path")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Check result path is too long");
+				nm_asprintf(&error_message, "Check result path is too long");
 				error = TRUE;
 				break;
 			}
@@ -219,7 +210,7 @@ int read_main_config_file(const char *main_config_file)
 				check_result_path[strlen(check_result_path) - 1] = '\x0';
 
 			if ((tmpdir = opendir(check_result_path)) == NULL) {
-				asprintf(&error_message, "Check result path '%s' is not a valid directory", check_result_path);
+				nm_asprintf(&error_message, "Check result path '%s' is not a valid directory", check_result_path);
 				error = TRUE;
 				break;
 			}
@@ -233,7 +224,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "lock_file")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Lock file is too long");
+				nm_asprintf(&error_message, "Lock file is too long");
 				error = TRUE;
 				break;
 			}
@@ -244,52 +235,52 @@ int read_main_config_file(const char *main_config_file)
 
 		else if (!strcmp(variable, "global_host_event_handler")) {
 			my_free(global_host_event_handler);
-			global_host_event_handler = (char *)strdup(value);
+			global_host_event_handler = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "global_service_event_handler")) {
 			my_free(global_service_event_handler);
-			global_service_event_handler = (char *)strdup(value);
+			global_service_event_handler = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "ocsp_command")) {
 			my_free(ocsp_command);
-			ocsp_command = (char *)strdup(value);
+			ocsp_command = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "ochp_command")) {
 			my_free(ochp_command);
-			ochp_command = (char *)strdup(value);
+			ochp_command = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "nagios_user") || !strcmp(variable, "naemon_user")) {
 			my_free(naemon_user);
-			naemon_user = (char *)strdup(value);
+			naemon_user = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "nagios_group") || !strcmp(variable, "naemon_group")) {
 			my_free(naemon_group);
-			naemon_group = (char *)strdup(value);
+			naemon_group = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "admin_email")) {
 
 			/* save the macro */
 			my_free(mac->x[MACRO_ADMINEMAIL]);
-			mac->x[MACRO_ADMINEMAIL] = (char *)strdup(value);
+			mac->x[MACRO_ADMINEMAIL] = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "admin_pager")) {
 
 			/* save the macro */
 			my_free(mac->x[MACRO_ADMINPAGER]);
-			mac->x[MACRO_ADMINPAGER] = (char *)strdup(value);
+			mac->x[MACRO_ADMINPAGER] = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "use_syslog")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for use_syslog");
+				nm_asprintf(&error_message, "Illegal value for use_syslog");
 				error = TRUE;
 				break;
 			}
@@ -300,7 +291,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_notifications")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_notifications");
+				nm_asprintf(&error_message, "Illegal value for log_notifications");
 				error = TRUE;
 				break;
 			}
@@ -311,7 +302,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_service_retries")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_service_retries");
+				nm_asprintf(&error_message, "Illegal value for log_service_retries");
 				error = TRUE;
 				break;
 			}
@@ -322,7 +313,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_host_retries")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_host_retries");
+				nm_asprintf(&error_message, "Illegal value for log_host_retries");
 				error = TRUE;
 				break;
 			}
@@ -333,7 +324,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_event_handlers")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_event_handlers");
+				nm_asprintf(&error_message, "Illegal value for log_event_handlers");
 				error = TRUE;
 				break;
 			}
@@ -344,7 +335,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_external_commands")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_external_commands");
+				nm_asprintf(&error_message, "Illegal value for log_external_commands");
 				error = TRUE;
 				break;
 			}
@@ -355,7 +346,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_passive_checks")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_passive_checks");
+				nm_asprintf(&error_message, "Illegal value for log_passive_checks");
 				error = TRUE;
 				break;
 			}
@@ -366,7 +357,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_initial_states")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_initial_states");
+				nm_asprintf(&error_message, "Illegal value for log_initial_states");
 				error = TRUE;
 				break;
 			}
@@ -377,7 +368,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "log_current_states")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for log_current_states");
+				nm_asprintf(&error_message, "Illegal value for log_current_states");
 				error = TRUE;
 				break;
 			}
@@ -388,7 +379,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "retain_state_information")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for retain_state_information");
+				nm_asprintf(&error_message, "Illegal value for retain_state_information");
 				error = TRUE;
 				break;
 			}
@@ -400,7 +391,7 @@ int read_main_config_file(const char *main_config_file)
 
 			retention_update_interval = atoi(value);
 			if (retention_update_interval < 0) {
-				asprintf(&error_message, "Illegal value for retention_update_interval");
+				nm_asprintf(&error_message, "Illegal value for retention_update_interval");
 				error = TRUE;
 				break;
 			}
@@ -409,7 +400,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "use_retained_program_state")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for use_retained_program_state");
+				nm_asprintf(&error_message, "Illegal value for use_retained_program_state");
 				error = TRUE;
 				break;
 			}
@@ -420,7 +411,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "use_retained_scheduling_info")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for use_retained_scheduling_info");
+				nm_asprintf(&error_message, "Illegal value for use_retained_scheduling_info");
 				error = TRUE;
 				break;
 			}
@@ -433,7 +424,7 @@ int read_main_config_file(const char *main_config_file)
 			retention_scheduling_horizon = atoi(value);
 
 			if (retention_scheduling_horizon <= 0) {
-				asprintf(&error_message, "Illegal value for retention_scheduling_horizon");
+				nm_asprintf(&error_message, "Illegal value for retention_scheduling_horizon");
 				error = TRUE;
 				break;
 			}
@@ -463,7 +454,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "obsess_over_services")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for obsess_over_services");
+				nm_asprintf(&error_message, "Illegal value for obsess_over_services");
 				error = TRUE;
 				break;
 			}
@@ -474,7 +465,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "obsess_over_hosts")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for obsess_over_hosts");
+				nm_asprintf(&error_message, "Illegal value for obsess_over_hosts");
 				error = TRUE;
 				break;
 			}
@@ -485,7 +476,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "translate_passive_host_checks")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for translate_passive_host_checks");
+				nm_asprintf(&error_message, "Illegal value for translate_passive_host_checks");
 				error = TRUE;
 				break;
 			}
@@ -501,7 +492,7 @@ int read_main_config_file(const char *main_config_file)
 			service_check_timeout = atoi(value);
 
 			if (service_check_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for service_check_timeout");
+				nm_asprintf(&error_message, "Illegal value for service_check_timeout");
 				error = TRUE;
 				break;
 			}
@@ -519,7 +510,7 @@ int read_main_config_file(const char *main_config_file)
 			else if (!strcmp(value, "u"))
 				service_check_timeout_state = STATE_UNKNOWN;
 			else {
-				asprintf(&error_message, "Illegal value for service_check_timeout_state");
+				nm_asprintf(&error_message, "Illegal value for service_check_timeout_state");
 				error = TRUE;
 				break;
 			}
@@ -530,7 +521,7 @@ int read_main_config_file(const char *main_config_file)
 			host_check_timeout = atoi(value);
 
 			if (host_check_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for host_check_timeout");
+				nm_asprintf(&error_message, "Illegal value for host_check_timeout");
 				error = TRUE;
 				break;
 			}
@@ -541,7 +532,7 @@ int read_main_config_file(const char *main_config_file)
 			event_handler_timeout = atoi(value);
 
 			if (event_handler_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for event_handler_timeout");
+				nm_asprintf(&error_message, "Illegal value for event_handler_timeout");
 				error = TRUE;
 				break;
 			}
@@ -552,7 +543,7 @@ int read_main_config_file(const char *main_config_file)
 			notification_timeout = atoi(value);
 
 			if (notification_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for notification_timeout");
+				nm_asprintf(&error_message, "Illegal value for notification_timeout");
 				error = TRUE;
 				break;
 			}
@@ -563,7 +554,7 @@ int read_main_config_file(const char *main_config_file)
 			ocsp_timeout = atoi(value);
 
 			if (ocsp_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for ocsp_timeout");
+				nm_asprintf(&error_message, "Illegal value for ocsp_timeout");
 				error = TRUE;
 				break;
 			}
@@ -574,7 +565,7 @@ int read_main_config_file(const char *main_config_file)
 			ochp_timeout = atoi(value);
 
 			if (ochp_timeout <= 0) {
-				asprintf(&error_message, "Illegal value for ochp_timeout");
+				nm_asprintf(&error_message, "Illegal value for ochp_timeout");
 				error = TRUE;
 				break;
 			}
@@ -583,7 +574,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "use_agressive_host_checking") || !strcmp(variable, "use_aggressive_host_checking")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for use_aggressive_host_checking");
+				nm_asprintf(&error_message, "Illegal value for use_aggressive_host_checking");
 				error = TRUE;
 				break;
 			}
@@ -605,7 +596,7 @@ int read_main_config_file(const char *main_config_file)
 
 		else if (!strcmp(variable, "soft_state_dependencies")) {
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for soft_state_dependencies");
+				nm_asprintf(&error_message, "Illegal value for soft_state_dependencies");
 				error = TRUE;
 				break;
 			}
@@ -623,7 +614,7 @@ int read_main_config_file(const char *main_config_file)
 			 * find the log archive at all.
 			 */
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
-				asprintf(&error_message, "Log archive path too long");
+				nm_asprintf(&error_message, "Log archive path too long");
 				error = TRUE;
 				break;
 			}
@@ -661,7 +652,7 @@ int read_main_config_file(const char *main_config_file)
 				service_inter_check_delay_method = ICD_USER;
 				scheduling_info.service_inter_check_delay = strtod(value, NULL);
 				if (scheduling_info.service_inter_check_delay <= 0.0) {
-					asprintf(&error_message, "Illegal value for service_inter_check_delay_method");
+					nm_asprintf(&error_message, "Illegal value for service_inter_check_delay_method");
 					error = TRUE;
 					break;
 				}
@@ -672,7 +663,7 @@ int read_main_config_file(const char *main_config_file)
 			strip(value);
 			max_service_check_spread = atoi(value);
 			if (max_service_check_spread < 1) {
-				asprintf(&error_message, "Illegal value for max_service_check_spread");
+				nm_asprintf(&error_message, "Illegal value for max_service_check_spread");
 				error = TRUE;
 				break;
 			}
@@ -690,7 +681,7 @@ int read_main_config_file(const char *main_config_file)
 				host_inter_check_delay_method = ICD_USER;
 				scheduling_info.host_inter_check_delay = strtod(value, NULL);
 				if (scheduling_info.host_inter_check_delay <= 0.0) {
-					asprintf(&error_message, "Illegal value for host_inter_check_delay_method");
+					nm_asprintf(&error_message, "Illegal value for host_inter_check_delay_method");
 					error = TRUE;
 					break;
 				}
@@ -701,7 +692,7 @@ int read_main_config_file(const char *main_config_file)
 
 			max_host_check_spread = atoi(value);
 			if (max_host_check_spread < 1) {
-				asprintf(&error_message, "Illegal value for max_host_check_spread");
+				nm_asprintf(&error_message, "Illegal value for max_host_check_spread");
 				error = TRUE;
 				break;
 			}
@@ -722,7 +713,7 @@ int read_main_config_file(const char *main_config_file)
 
 			max_parallel_service_checks = atoi(value);
 			if (max_parallel_service_checks < 0) {
-				asprintf(&error_message, "Illegal value for max_concurrent_checks");
+				nm_asprintf(&error_message, "Illegal value for max_concurrent_checks");
 				error = TRUE;
 				break;
 			}
@@ -732,7 +723,7 @@ int read_main_config_file(const char *main_config_file)
 
 			check_reaper_interval = atoi(value);
 			if (check_reaper_interval < 1) {
-				asprintf(&error_message, "Illegal value for check_result_reaper_frequency");
+				nm_asprintf(&error_message, "Illegal value for check_result_reaper_frequency");
 				error = TRUE;
 				break;
 			}
@@ -742,7 +733,7 @@ int read_main_config_file(const char *main_config_file)
 
 			max_check_reaper_time = atoi(value);
 			if (max_check_reaper_time < 1) {
-				asprintf(&error_message, "Illegal value for max_check_result_reaper_time");
+				nm_asprintf(&error_message, "Illegal value for max_check_result_reaper_time");
 				error = TRUE;
 				break;
 			}
@@ -756,7 +747,7 @@ int read_main_config_file(const char *main_config_file)
 
 			interval_length = atoi(value);
 			if (interval_length < 1) {
-				asprintf(&error_message, "Illegal value for interval_length");
+				nm_asprintf(&error_message, "Illegal value for interval_length");
 				error = TRUE;
 				break;
 			}
@@ -765,7 +756,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_external_commands")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for check_external_commands");
+				nm_asprintf(&error_message, "Illegal value for check_external_commands");
 				error = TRUE;
 				break;
 			}
@@ -781,7 +772,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_for_orphaned_services")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for check_for_orphaned_services");
+				nm_asprintf(&error_message, "Illegal value for check_for_orphaned_services");
 				error = TRUE;
 				break;
 			}
@@ -792,7 +783,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_for_orphaned_hosts")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for check_for_orphaned_hosts");
+				nm_asprintf(&error_message, "Illegal value for check_for_orphaned_hosts");
 				error = TRUE;
 				break;
 			}
@@ -803,7 +794,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_service_freshness")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for check_service_freshness");
+				nm_asprintf(&error_message, "Illegal value for check_service_freshness");
 				error = TRUE;
 				break;
 			}
@@ -814,7 +805,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "check_host_freshness")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for check_host_freshness");
+				nm_asprintf(&error_message, "Illegal value for check_host_freshness");
 				error = TRUE;
 				break;
 			}
@@ -826,7 +817,7 @@ int read_main_config_file(const char *main_config_file)
 
 			service_freshness_check_interval = atoi(value);
 			if (service_freshness_check_interval <= 0) {
-				asprintf(&error_message, "Illegal value for service_freshness_check_interval");
+				nm_asprintf(&error_message, "Illegal value for service_freshness_check_interval");
 				error = TRUE;
 				break;
 			}
@@ -836,7 +827,7 @@ int read_main_config_file(const char *main_config_file)
 
 			host_freshness_check_interval = atoi(value);
 			if (host_freshness_check_interval <= 0) {
-				asprintf(&error_message, "Illegal value for host_freshness_check_interval");
+				nm_asprintf(&error_message, "Illegal value for host_freshness_check_interval");
 				error = TRUE;
 				break;
 			}
@@ -856,7 +847,7 @@ int read_main_config_file(const char *main_config_file)
 
 			status_update_interval = atoi(value);
 			if (status_update_interval <= 1) {
-				asprintf(&error_message, "Illegal value for status_update_interval");
+				nm_asprintf(&error_message, "Illegal value for status_update_interval");
 				error = TRUE;
 				break;
 			}
@@ -867,7 +858,7 @@ int read_main_config_file(const char *main_config_file)
 			time_change_threshold = atoi(value);
 
 			if (time_change_threshold <= 5) {
-				asprintf(&error_message, "Illegal value for time_change_threshold");
+				nm_asprintf(&error_message, "Illegal value for time_change_threshold");
 				error = TRUE;
 				break;
 			}
@@ -886,7 +877,7 @@ int read_main_config_file(const char *main_config_file)
 
 			low_service_flap_threshold = strtod(value, NULL);
 			if (low_service_flap_threshold <= 0.0 || low_service_flap_threshold >= 100.0) {
-				asprintf(&error_message, "Illegal value for low_service_flap_threshold");
+				nm_asprintf(&error_message, "Illegal value for low_service_flap_threshold");
 				error = TRUE;
 				break;
 			}
@@ -896,7 +887,7 @@ int read_main_config_file(const char *main_config_file)
 
 			high_service_flap_threshold = strtod(value, NULL);
 			if (high_service_flap_threshold <= 0.0 ||  high_service_flap_threshold > 100.0) {
-				asprintf(&error_message, "Illegal value for high_service_flap_threshold");
+				nm_asprintf(&error_message, "Illegal value for high_service_flap_threshold");
 				error = TRUE;
 				break;
 			}
@@ -906,7 +897,7 @@ int read_main_config_file(const char *main_config_file)
 
 			low_host_flap_threshold = strtod(value, NULL);
 			if (low_host_flap_threshold <= 0.0 || low_host_flap_threshold >= 100.0) {
-				asprintf(&error_message, "Illegal value for low_host_flap_threshold");
+				nm_asprintf(&error_message, "Illegal value for low_host_flap_threshold");
 				error = TRUE;
 				break;
 			}
@@ -916,7 +907,7 @@ int read_main_config_file(const char *main_config_file)
 
 			high_host_flap_threshold = strtod(value, NULL);
 			if (high_host_flap_threshold <= 0.0 || high_host_flap_threshold > 100.0) {
-				asprintf(&error_message, "Illegal value for high_host_flap_threshold");
+				nm_asprintf(&error_message, "Illegal value for high_host_flap_threshold");
 				error = TRUE;
 				break;
 			}
@@ -936,7 +927,7 @@ int read_main_config_file(const char *main_config_file)
 
 		else if (!strcmp(variable, "use_timezone")) {
 			my_free(use_timezone);
-			use_timezone = (char *)strdup(value);
+			use_timezone = nm_strdup(value);
 		}
 
 		else if (!strcmp(variable, "event_broker_options")) {
@@ -948,10 +939,10 @@ int read_main_config_file(const char *main_config_file)
 		}
 
 		else if (!strcmp(variable, "illegal_object_name_chars"))
-			illegal_object_chars = (char *)strdup(value);
+			illegal_object_chars = nm_strdup(value);
 
 		else if (!strcmp(variable, "illegal_macro_output_chars"))
-			illegal_output_chars = (char *)strdup(value);
+			illegal_output_chars = nm_strdup(value);
 
 
 		else if (!strcmp(variable, "broker_module")) {
@@ -977,7 +968,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "daemon_dumps_core")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for daemon_dumps_core");
+				nm_asprintf(&error_message, "Illegal value for daemon_dumps_core");
 				error = TRUE;
 				break;
 			}
@@ -988,7 +979,7 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "use_large_installation_tweaks")) {
 
 			if (strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
-				asprintf(&error_message, "Illegal value for use_large_installation_tweaks ");
+				nm_asprintf(&error_message, "Illegal value for use_large_installation_tweaks ");
 				error = TRUE;
 				break;
 			}
@@ -1035,13 +1026,13 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "perfdata_timeout")) {
 			perfdata_timeout = atoi(value);
 		} else if (!strcmp(variable, "host_perfdata_command"))
-			host_perfdata_command = (char *)strdup(value);
+			host_perfdata_command = nm_strdup(value);
 		else if (!strcmp(variable, "service_perfdata_command"))
-			service_perfdata_command = (char *)strdup(value);
+			service_perfdata_command = nm_strdup(value);
 		else if (!strcmp(variable, "host_perfdata_file_template"))
-			host_perfdata_file_template = (char *)strdup(value);
+			host_perfdata_file_template = nm_strdup(value);
 		else if (!strcmp(variable, "service_perfdata_file_template"))
-			service_perfdata_file_template = (char *)strdup(value);
+			service_perfdata_file_template = nm_strdup(value);
 		else if (!strcmp(variable, "host_perfdata_file"))
 			host_perfdata_file = nspath_absolute(value, config_file_dir);
 		else if (!strcmp(variable, "service_perfdata_file"))
@@ -1067,9 +1058,9 @@ int read_main_config_file(const char *main_config_file)
 		else if (!strcmp(variable, "service_perfdata_file_processing_interval"))
 			service_perfdata_file_processing_interval = strtoul(value, NULL, 0);
 		else if (!strcmp(variable, "host_perfdata_file_processing_command"))
-			host_perfdata_file_processing_command = (char *)strdup(value);
+			host_perfdata_file_processing_command = nm_strdup(value);
 		else if (!strcmp(variable, "service_perfdata_file_processing_command"))
-			service_perfdata_file_processing_command = (char *)strdup(value);
+			service_perfdata_file_processing_command = nm_strdup(value);
 		else if (!strcmp(variable, "host_perfdata_process_empty_results"))
 			host_perfdata_process_empty_results = (atoi(value) > 0) ? TRUE : FALSE;
 		else if (!strcmp(variable, "service_perfdata_process_empty_results"))
@@ -1082,7 +1073,7 @@ int read_main_config_file(const char *main_config_file)
 			my_free(object_cache_file);
 			object_cache_file = nspath_absolute(value, config_file_dir);
 			my_free(mac->x[MACRO_OBJECTCACHEFILE]);
-			mac->x[MACRO_OBJECTCACHEFILE] = strdup(object_cache_file);
+			mac->x[MACRO_OBJECTCACHEFILE] = nm_strdup(object_cache_file);
 		} else if (strstr(input, "precached_object_file=") == input) {
 			my_free(object_precache_file);
 			object_precache_file = nspath_absolute(value, config_file_dir);
@@ -1095,7 +1086,7 @@ int read_main_config_file(const char *main_config_file)
 
 		/* we don't know what this variable is... */
 		else {
-			asprintf(&error_message, "UNKNOWN VARIABLE");
+			nm_asprintf(&error_message, "UNKNOWN VARIABLE");
 			error = TRUE;
 			break;
 		}
@@ -1118,7 +1109,7 @@ int read_main_config_file(const char *main_config_file)
 		if (!temp_path)
 			temp_path = "/tmp";
 
-		temp_path = strdup(temp_path);
+		temp_path = nm_strdup(temp_path);
 	} else {
 		/* make sure we don't have a trailing slash */
 		if (temp_path[strlen(temp_path) - 1] == '/')
@@ -1245,10 +1236,7 @@ int read_resource_file(const char *resource_file)
 			error = TRUE;
 			break;
 		}
-		if ((variable = (char *)strdup(temp_ptr)) == NULL) {
-			error = TRUE;
-			break;
-		}
+		variable = (char *)nm_strdup(temp_ptr);
 
 		/* get the value */
 		if ((temp_ptr = my_strtok(NULL, "\n")) == NULL) {
@@ -1256,11 +1244,7 @@ int read_resource_file(const char *resource_file)
 			error = TRUE;
 			break;
 		}
-		if ((value = (char *)strdup(temp_ptr)) == NULL) {
-			error = TRUE;
-			break;
-		}
-
+		value = nm_strdup(temp_ptr);
 		/* what should we do with the variable/value pair? */
 
 		/* check for macro declarations */
@@ -1271,7 +1255,7 @@ int read_resource_file(const char *resource_file)
 				user_index = atoi(variable + 5) - 1;
 				if (user_index >= 0 && user_index < MAX_USER_MACROS) {
 					my_free(macro_user[user_index]);
-					macro_user[user_index] = (char *)strdup(value);
+					macro_user[user_index] = nm_strdup(value);
 				}
 			}
 		}
@@ -1375,7 +1359,7 @@ int pre_flight_check(void)
 		printf("Checking misc settings...\n");
 
 	/* check if we can write to temp_path */
-	asprintf(&buf, "%s/nagiosXXXXXX", temp_path);
+	nm_asprintf(&buf, "%s/nagiosXXXXXX", temp_path);
 	if ((temp_path_fd = mkstemp(buf)) == -1) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "\tError: Unable to write to temp_path ('%s') - %s\n", temp_path, strerror(errno));
 		errors++;
@@ -1386,7 +1370,7 @@ int pre_flight_check(void)
 	my_free(buf);
 
 	/* check if we can write to check_result_path */
-	asprintf(&buf, "%s/nagiosXXXXXX", check_result_path);
+	nm_asprintf(&buf, "%s/nagiosXXXXXX", check_result_path);
 	if ((temp_path_fd = mkstemp(buf)) == -1) {
 		logit(NSLOG_VERIFICATION_WARNING, TRUE, "\tError: Unable to write to check_result_path ('%s') - %s\n", check_result_path, strerror(errno));
 		errors++;
@@ -2103,14 +2087,7 @@ int pre_flight_circular_check(int *w, int *e)
 		alloc = num_objects.timeperiods;
 
 	for (i = 0; i < ARRAY_SIZE(ary); i++) {
-		if (!(ary[i] = calloc(1, alloc))) {
-			while (i) {
-				my_free(ary[--i]);
-			}
-			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to allocate memory for circular path checks.\n");
-			errors++;
-			return ERROR;
-		}
+		ary[i] = nm_calloc(1, alloc);
 	}
 
 

--- a/naemon/events.c
+++ b/naemon/events.c
@@ -15,6 +15,7 @@
 #include "globals.h"
 #include "defaults.h"
 #include "loadctl.h"
+#include "nm_alloc.h"
 #include <math.h>
 #include <string.h>
 
@@ -761,7 +762,7 @@ timed_event *schedule_new_event(int event_type, int high_priority, time_t run_ti
 	log_debug_info(DEBUGL_EVENTS, 0, " Event Options:              %d\n",
 	               event_options);
 
-	new_event = (timed_event *)calloc(1, sizeof(timed_event));
+	new_event = nm_calloc(1, sizeof(timed_event));
 	if (new_event != NULL) {
 		new_event->event_type = event_type;
 		new_event->event_data = event_data;

--- a/naemon/flapping.c
+++ b/naemon/flapping.c
@@ -8,6 +8,7 @@
 #include "notifications.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 
 
 /******************************************************************/
@@ -222,7 +223,7 @@ void set_service_flap(service *svc, double percent_change, double high_threshold
 	logit(NSLOG_RUNTIME_WARNING, FALSE, "SERVICE FLAPPING ALERT: %s;%s;STARTED; Service appears to have started flapping (%2.1f%% change >= %2.1f%% threshold)\n", svc->host_name, svc->description, percent_change, high_threshold);
 
 	/* add a non-persistent comment to the service */
-	asprintf(&temp_buffer, "Notifications for this service are being suppressed because it was detected as having been flapping between different states (%2.1f%% change >= %2.1f%% threshold).  When the service state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
+	nm_asprintf(&temp_buffer, "Notifications for this service are being suppressed because it was detected as having been flapping between different states (%2.1f%% change >= %2.1f%% threshold).  When the service state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
 	add_new_service_comment(FLAPPING_COMMENT, svc->host_name, svc->description, time(NULL), "(Naemon Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(svc->flapping_comment_id));
 	my_free(temp_buffer);
 
@@ -305,7 +306,7 @@ void set_host_flap(host *hst, double percent_change, double high_threshold, doub
 	logit(NSLOG_RUNTIME_WARNING, FALSE, "HOST FLAPPING ALERT: %s;STARTED; Host appears to have started flapping (%2.1f%% change > %2.1f%% threshold)\n", hst->name, percent_change, high_threshold);
 
 	/* add a non-persistent comment to the host */
-	asprintf(&temp_buffer, "Notifications for this host are being suppressed because it was detected as having been flapping between different states (%2.1f%% change > %2.1f%% threshold).  When the host state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
+	nm_asprintf(&temp_buffer, "Notifications for this host are being suppressed because it was detected as having been flapping between different states (%2.1f%% change > %2.1f%% threshold).  When the host state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
 	add_new_host_comment(FLAPPING_COMMENT, hst->name, time(NULL), "(Naemon Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(hst->flapping_comment_id));
 	my_free(temp_buffer);
 

--- a/naemon/logging.c
+++ b/naemon/logging.c
@@ -6,6 +6,7 @@
 #include "broker.h"
 #include "utils.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 #include <fcntl.h>
 #include <syslog.h>
@@ -235,7 +236,7 @@ int log_service_event(service *svc)
 	if ((temp_host = svc->host_ptr) == NULL)
 		return ERROR;
 
-	asprintf(&temp_buffer, "SERVICE ALERT: %s;%s;%s;%s;%d;%s\n",
+	nm_asprintf(&temp_buffer, "SERVICE ALERT: %s;%s;%s;%s;%d;%s\n",
 	         svc->host_name, svc->description,
 	         service_state_name(svc->current_state),
 	         state_type_name(svc->state_type),
@@ -263,7 +264,7 @@ int log_host_event(host *hst)
 	else
 		log_options = NSLOG_HOST_UP;
 
-	asprintf(&temp_buffer, "HOST ALERT: %s;%s;%s;%d;%s\n",
+	nm_asprintf(&temp_buffer, "HOST ALERT: %s;%s;%s;%d;%s\n",
 	         hst->name,
 	         host_state_name(hst->current_state),
 	         state_type_name(hst->state_type),
@@ -290,7 +291,7 @@ int log_host_states(int type, time_t *timestamp)
 
 	for (temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
-		asprintf(&temp_buffer, "%s HOST STATE: %s;%s;%s;%d;%s\n", (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
+		nm_asprintf(&temp_buffer, "%s HOST STATE: %s;%s;%s;%d;%s\n", (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
 		         temp_host->name,
 		         host_state_name(temp_host->current_state),
 		         state_type_name(temp_host->state_type),
@@ -323,7 +324,7 @@ int log_service_states(int type, time_t *timestamp)
 		if ((temp_host = temp_service->host_ptr) == NULL)
 			continue;
 
-		asprintf(&temp_buffer, "%s SERVICE STATE: %s;%s;%s;%s;%d;%s\n",
+		nm_asprintf(&temp_buffer, "%s SERVICE STATE: %s;%s;%s;%s;%d;%s\n",
 		         (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
 		         temp_service->host_name, temp_service->description,
 		         service_state_name(temp_service->current_state),
@@ -378,7 +379,7 @@ int write_log_file_info(time_t *timestamp)
 	char *temp_buffer = NULL;
 
 	/* write log version */
-	asprintf(&temp_buffer, "LOG VERSION: %s\n", LOG_VERSION_2);
+	nm_asprintf(&temp_buffer, "LOG VERSION: %s\n", LOG_VERSION_2);
 	write_to_all_logs_with_timestamp(temp_buffer, NSLOG_PROCESS_INFO, timestamp);
 	my_free(temp_buffer);
 
@@ -455,7 +456,7 @@ int log_debug_info(int level, int verbosity, const char *fmt, ...)
 		close_debug_log();
 
 		/* rotate the log file */
-		asprintf(&tmppath, "%s.old", debug_file);
+		nm_asprintf(&tmppath, "%s.old", debug_file);
 		if (tmppath) {
 
 			/* unlink the old debug file */

--- a/naemon/naemon.c
+++ b/naemon/naemon.c
@@ -21,6 +21,7 @@
 #include "loadctl.h"
 #include "globals.h"
 #include "logging.h"
+#include "nm_alloc.h"
 #include <getopt.h>
 #include <string.h>
 
@@ -91,7 +92,7 @@ static int test_path_access(const char *program, int mode)
 		colon = strchr(p, ':');
 		if (colon)
 			*colon = 0;
-		asprintf(&path, "%s/%s", p, program);
+		nm_asprintf(&path, "%s/%s", p, program);
 		ret = access(path, mode);
 		free(path);
 		if (!ret)
@@ -505,7 +506,7 @@ int main(int argc, char **argv)
 	if (strchr(argv[0], '/'))
 		naemon_binary_path = nspath_absolute(argv[0], NULL);
 	else
-		naemon_binary_path = strdup(argv[0]);
+		naemon_binary_path = nm_strdup(argv[0]);
 
 	if (!naemon_binary_path) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to allocate memory for naemon_binary_path\n");
@@ -544,7 +545,7 @@ int main(int argc, char **argv)
 		/* get program (re)start time and save as macro */
 		program_start = time(NULL);
 		my_free(mac->x[MACRO_PROCESSSTARTTIME]);
-		asprintf(&mac->x[MACRO_PROCESSSTARTTIME], "%lu", (unsigned long)program_start);
+		nm_asprintf(&mac->x[MACRO_PROCESSSTARTTIME], "%lu", (unsigned long)program_start);
 
 		/* drop privileges */
 		if (drop_privileges(naemon_user, naemon_group) == ERROR) {
@@ -762,7 +763,7 @@ int main(int argc, char **argv)
 		/* get event start time and save as macro */
 		event_start = time(NULL);
 		my_free(mac->x[MACRO_EVENTSTARTTIME]);
-		asprintf(&mac->x[MACRO_EVENTSTARTTIME], "%lu", (unsigned long)event_start);
+		nm_asprintf(&mac->x[MACRO_EVENTSTARTTIME], "%lu", (unsigned long)event_start);
 
 		timing_point("Entering event execution loop\n");
 		/***** start monitoring all services *****/

--- a/naemon/nebmods.c
+++ b/naemon/nebmods.c
@@ -4,6 +4,7 @@
 #include "neberrors.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 #ifdef USE_EVENT_BROKER
@@ -59,13 +60,11 @@ int neb_add_module(char *filename, char *args, int should_be_loaded)
 		return ERROR;
 
 	/* allocate memory */
-	new_module = (nebmodule *)calloc(1, sizeof(nebmodule));
-	if (new_module == NULL)
-		return ERROR;
+	new_module = nm_calloc(1, sizeof(nebmodule));
 
 	/* initialize vars */
-	new_module->filename = (char *)strdup(filename);
-	new_module->args = (args == NULL) ? NULL : (char *)strdup(args);
+	new_module->filename = nm_strdup(filename);
+	new_module->args = (args == NULL) ? NULL : nm_strdup(args);
 	new_module->should_be_loaded = should_be_loaded;
 	new_module->is_currently_loaded = FALSE;
 	for (x = 0; x < NEBMODULE_MODINFO_NUMITEMS; x++)
@@ -341,9 +340,7 @@ int neb_set_module_info(void *handle, int type, char *data)
 	my_free(temp_module->info[type]);
 
 	/* allocate memory for the new data */
-	if ((temp_module->info[type] = (char *)strdup(data)) == NULL)
-		return NEBERROR_NOMEM;
-
+	temp_module->info[type] = nm_strdup(data);
 	return OK;
 }
 
@@ -385,10 +382,7 @@ int neb_register_callback(int callback_type, void *mod_handle, int priority, int
 		return NEBERROR_BADMODULEHANDLE;
 
 	/* allocate memory */
-	new_callback = (nebcallback *)malloc(sizeof(nebcallback));
-	if (new_callback == NULL)
-		return NEBERROR_NOMEM;
-
+	new_callback = nm_malloc(sizeof(nebcallback));
 	new_callback->priority = priority;
 	new_callback->module_handle = mod_handle;
 	new_callback->callback_func = callback_func;
@@ -542,9 +536,7 @@ int neb_init_callback_list(void)
 	register int x = 0;
 
 	/* allocate memory for the callback list */
-	neb_callback_list = (nebcallback **)malloc(NEBCALLBACK_NUMITEMS * sizeof(nebcallback *));
-	if (neb_callback_list == NULL)
-		return ERROR;
+	neb_callback_list = nm_calloc(NEBCALLBACK_NUMITEMS, sizeof(nebcallback *));
 
 	/* initialize list pointers */
 	for (x = 0; x < NEBCALLBACK_NUMITEMS; x++)

--- a/naemon/nm_alloc.c
+++ b/naemon/nm_alloc.c
@@ -1,0 +1,58 @@
+#include <string.h>
+#include <stdarg.h>
+#include "logging.h"
+#include "nm_alloc.h"
+
+#ifndef __func__
+# if __STDC_VERSION__ < 199901L
+#  if __GNUC__ >= 2
+#   define __func__ __FUNCTION__
+#  else
+#   define __func__ "<unknown>"
+#  endif
+# endif
+#endif
+#define log_mem_error() logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to allocate memory in %s", __func__);
+#define log_vasprintf_error() logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to vasprintf in %s", __func__);
+
+#define CHECK_AND_RETURN(_ptr)					\
+	if (_ptr == NULL) {							\
+		log_mem_error();						\
+		exit(2);								\
+	}											\
+	return _ptr;
+
+void *nm_malloc(size_t size) {
+	void *ptr = malloc(size);
+	CHECK_AND_RETURN(ptr);
+}
+
+void *nm_realloc(void *ptr, size_t size)  {
+	void *new_ptr = realloc(ptr, size);
+	CHECK_AND_RETURN(new_ptr);
+}
+
+void *nm_calloc(size_t count, size_t size) {
+	void *ptr = calloc(count, size);
+	CHECK_AND_RETURN(ptr);
+}
+
+void *nm_strdup(const char *s) {
+	char *str = strdup(s);
+	CHECK_AND_RETURN(str);
+}
+
+void *nm_strndup(const char *s, size_t size) {
+	char *str = strndup(s, size);
+	CHECK_AND_RETURN(str);
+}
+
+void nm_asprintf(char **strp, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	if (vasprintf(strp, fmt, ap) < 0) {
+		log_vasprintf_error();
+		exit(2);
+	}
+	va_end(ap);
+}

--- a/naemon/nm_alloc.h
+++ b/naemon/nm_alloc.h
@@ -1,0 +1,9 @@
+#ifndef _NM_ALLOC_H
+#define _NM_ALLOC_H
+void *nm_malloc(size_t size);
+void *nm_realloc(void *ptr, size_t size);
+void *nm_calloc(size_t count, size_t size);
+void *nm_strdup(const char *s);
+void *nm_strndup(const char *s, size_t size);
+void nm_asprintf(char **strp, const char *fmt, ...);
+#endif

--- a/naemon/notifications.c
+++ b/naemon/notifications.c
@@ -11,6 +11,7 @@
 #include "checks.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 struct notification_job {
@@ -170,26 +171,26 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 
 		/* get author and comment macros */
 		if (not_author)
-			mac.x[MACRO_NOTIFICATIONAUTHOR] = strdup(not_author);
+			mac.x[MACRO_NOTIFICATIONAUTHOR] = nm_strdup(not_author);
 		if (temp_contact != NULL) {
-			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = strdup(temp_contact->name);
-			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = strdup(temp_contact->alias);
+			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = nm_strdup(temp_contact->name);
+			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = nm_strdup(temp_contact->alias);
 		}
 		if (not_data)
-			mac.x[MACRO_NOTIFICATIONCOMMENT] = strdup(not_data);
+			mac.x[MACRO_NOTIFICATIONCOMMENT] = nm_strdup(not_data);
 
 		/* NOTE: these macros are deprecated and will likely disappear in Nagios 4.x */
 		/* if this is an acknowledgement, get author and comment macros */
 		if (type == NOTIFICATION_ACKNOWLEDGEMENT) {
 			if (not_author)
-				mac.x[MACRO_SERVICEACKAUTHOR] = strdup(not_author);
+				mac.x[MACRO_SERVICEACKAUTHOR] = nm_strdup(not_author);
 
 			if (not_data)
-				mac.x[MACRO_SERVICEACKCOMMENT] = strdup(not_data);
+				mac.x[MACRO_SERVICEACKCOMMENT] = nm_strdup(not_data);
 
 			if (temp_contact != NULL) {
-				mac.x[MACRO_SERVICEACKAUTHORNAME] = strdup(temp_contact->name);
-				mac.x[MACRO_SERVICEACKAUTHORALIAS] = strdup(temp_contact->alias);
+				mac.x[MACRO_SERVICEACKAUTHORNAME] = nm_strdup(temp_contact->name);
+				mac.x[MACRO_SERVICEACKAUTHORALIAS] = nm_strdup(temp_contact->alias);
 			}
 		}
 
@@ -215,16 +216,16 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 		else
 			mac.x[MACRO_NOTIFICATIONTYPE] = "PROBLEM";
 
-		mac.x[MACRO_NOTIFICATIONTYPE] = strdup(mac.x[MACRO_NOTIFICATIONTYPE]);
+		mac.x[MACRO_NOTIFICATIONTYPE] = nm_strdup(mac.x[MACRO_NOTIFICATIONTYPE]);
 
 		/* set the notification number macro */
-		asprintf(&mac.x[MACRO_SERVICENOTIFICATIONNUMBER], "%d", svc->current_notification_number);
+		nm_asprintf(&mac.x[MACRO_SERVICENOTIFICATIONNUMBER], "%d", svc->current_notification_number);
 
 		/* the $NOTIFICATIONNUMBER$ macro is maintained for backward compatability */
-		mac.x[MACRO_NOTIFICATIONNUMBER] = strdup(mac.x[MACRO_SERVICENOTIFICATIONNUMBER]);
+		mac.x[MACRO_NOTIFICATIONNUMBER] = nm_strdup(mac.x[MACRO_SERVICENOTIFICATIONNUMBER]);
 
 		/* set the notification id macro */
-		asprintf(&mac.x[MACRO_SERVICENOTIFICATIONID], "%lu", svc->current_notification_id);
+		nm_asprintf(&mac.x[MACRO_SERVICENOTIFICATIONID], "%lu", svc->current_notification_id);
 
 		/* notify each contact (duplicates have been removed) */
 		for (temp_notification = notification_list; temp_notification != NULL; temp_notification = temp_notification->next) {
@@ -756,7 +757,7 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 			continue;
 
 		/* get the command name */
-		command_name = (char *)strdup(temp_commandsmember->command);
+		command_name = nm_strdup(temp_commandsmember->command);
 		command_name_ptr = strtok(command_name, "!");
 
 		/* run the notification command... */
@@ -767,31 +768,31 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 		if (log_notifications == TRUE) {
 			switch (type) {
 			case NOTIFICATION_CUSTOM:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;CUSTOM ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;CUSTOM ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_ACKNOWLEDGEMENT:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;ACKNOWLEDGEMENT ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;ACKNOWLEDGEMENT ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGSTART:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGSTOP:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTOP ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTOP ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGDISABLED:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGDISABLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGDISABLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMESTART:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMESTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMESTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMEEND:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMEEND ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMEEND ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMECANCELLED:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMECANCELLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMECANCELLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			default:
-				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;$SERVICESTATE$;%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				nm_asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;$SERVICESTATE$;%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
 				break;
 			}
 
@@ -803,17 +804,13 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 		}
 
 		/* run the notification command */
-		nj = (struct notification_job*)calloc(1,sizeof(struct notification_job));
-		if(nj == NULL) {
-			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Allocating storage for notification job\n");
-		} else {
-			nj->ctc = cntct;
-			nj->hst = svc->host_ptr;
-			nj->svc = svc;
-			if(ERROR == wproc_run_callback(processed_command, notification_timeout, notification_handle_job_result, nj, mac)) {
-				logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to send notification for service '%s on host '%s' to worker\n", svc->description, svc->host_ptr->name);
-				free(nj);
-			}
+		nj = nm_calloc(1,sizeof(struct notification_job));
+		nj->ctc = cntct;
+		nj->hst = svc->host_ptr;
+		nj->svc = svc;
+		if(ERROR == wproc_run_callback(processed_command, notification_timeout, notification_handle_job_result, nj, mac)) {
+			logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to send notification for service '%s on host '%s' to worker\n", svc->description, svc->host_ptr->name);
+			free(nj);
 		}
 
 		/* free memory */
@@ -939,7 +936,7 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 	free_notification_list();
 
 	/* set the escalation macro */
-	mac->x[MACRO_NOTIFICATIONISESCALATED] = strdup(escalate_notification ? "1" : "0");
+	mac->x[MACRO_NOTIFICATIONISESCALATED] = nm_strdup(escalate_notification ? "1" : "0");
 
 	if (options & NOTIFICATION_OPTION_BROADCAST)
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This notification will be BROADCAST to all (escalated and normal) contacts...\n");
@@ -1120,27 +1117,27 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 
 		/* get author and comment macros */
 		if (not_author)
-			mac.x[MACRO_NOTIFICATIONAUTHOR] = strdup(not_author);
+			mac.x[MACRO_NOTIFICATIONAUTHOR] = nm_strdup(not_author);
 		if (temp_contact != NULL) {
-			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = strdup(temp_contact->name);
-			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = strdup(temp_contact->alias);
+			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = nm_strdup(temp_contact->name);
+			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = nm_strdup(temp_contact->alias);
 		}
 		if (not_data)
-			mac.x[MACRO_NOTIFICATIONCOMMENT] = strdup(not_data);
+			mac.x[MACRO_NOTIFICATIONCOMMENT] = nm_strdup(not_data);
 
 		/* NOTE: these macros are deprecated and will likely disappear in Nagios 4.x */
 		/* if this is an acknowledgement, get author and comment macros */
 		if (type == NOTIFICATION_ACKNOWLEDGEMENT) {
 
 			if (not_author)
-				mac.x[MACRO_HOSTACKAUTHOR] = strdup(not_author);
+				mac.x[MACRO_HOSTACKAUTHOR] = nm_strdup(not_author);
 
 			if (not_data)
-				mac.x[MACRO_HOSTACKCOMMENT] = strdup(not_data);
+				mac.x[MACRO_HOSTACKCOMMENT] = nm_strdup(not_data);
 
 			if (temp_contact != NULL) {
-				mac.x[MACRO_HOSTACKAUTHORNAME] = strdup(temp_contact->name);
-				mac.x[MACRO_HOSTACKAUTHORALIAS] = strdup(temp_contact->alias);
+				mac.x[MACRO_HOSTACKAUTHORNAME] = nm_strdup(temp_contact->name);
+				mac.x[MACRO_HOSTACKAUTHORALIAS] = nm_strdup(temp_contact->alias);
 			}
 		}
 
@@ -1166,16 +1163,16 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 		else
 			mac.x[MACRO_NOTIFICATIONTYPE] = "PROBLEM";
 
-		mac.x[MACRO_NOTIFICATIONTYPE] = strdup(mac.x[MACRO_NOTIFICATIONTYPE]);
+		mac.x[MACRO_NOTIFICATIONTYPE] = nm_strdup(mac.x[MACRO_NOTIFICATIONTYPE]);
 
 		/* set the notification number macro */
-		asprintf(&mac.x[MACRO_HOSTNOTIFICATIONNUMBER], "%d", hst->current_notification_number);
+		nm_asprintf(&mac.x[MACRO_HOSTNOTIFICATIONNUMBER], "%d", hst->current_notification_number);
 
 		/* the $NOTIFICATIONNUMBER$ macro is maintained for backward compatability */
-		mac.x[MACRO_NOTIFICATIONNUMBER] = strdup(mac.x[MACRO_HOSTNOTIFICATIONNUMBER]);
+		mac.x[MACRO_NOTIFICATIONNUMBER] = nm_strdup(mac.x[MACRO_HOSTNOTIFICATIONNUMBER]);
 
 		/* set the notification id macro */
-		asprintf(&mac.x[MACRO_HOSTNOTIFICATIONID], "%lu", hst->current_notification_id);
+		nm_asprintf(&mac.x[MACRO_HOSTNOTIFICATIONID], "%lu", hst->current_notification_id);
 
 		/* notify each contact (duplicates have been removed) */
 		for (temp_notification = notification_list; temp_notification != NULL; temp_notification = temp_notification->next) {
@@ -1663,7 +1660,7 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 			continue;
 
 		/* get the command name */
-		command_name = (char *)strdup(temp_commandsmember->command);
+		command_name = nm_strdup(temp_commandsmember->command);
 		command_name_ptr = strtok(command_name, "!");
 
 		/* run the notification command... */
@@ -1674,31 +1671,31 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 		if (log_notifications == TRUE) {
 			switch (type) {
 			case NOTIFICATION_CUSTOM:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;CUSTOM ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;CUSTOM ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_ACKNOWLEDGEMENT:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;ACKNOWLEDGEMENT ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;ACKNOWLEDGEMENT ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGSTART:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGSTOP:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTOP ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTOP ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_FLAPPINGDISABLED:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGDISABLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGDISABLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMESTART:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMESTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMESTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMEEND:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMEEND ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMEEND ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			case NOTIFICATION_DOWNTIMECANCELLED:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMECANCELLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMECANCELLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			default:
-				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;$HOSTSTATE$;%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				nm_asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;$HOSTSTATE$;%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
 				break;
 			}
 
@@ -1710,7 +1707,7 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 		}
 
 		/* run the notification command */
-		nj = (struct notification_job*)calloc(1,sizeof(struct notification_job));
+		nj = nm_calloc(1,sizeof(struct notification_job));
 		if(nj == NULL) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Allocating storage for notification job\n");
 		} else {
@@ -1847,7 +1844,7 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 	free_notification_list();
 
 	/* set the escalation macro */
-	mac->x[MACRO_NOTIFICATIONISESCALATED] = strdup(escalate_notification ? "1" : "0");
+	mac->x[MACRO_NOTIFICATIONISESCALATED] = nm_strdup(escalate_notification ? "1" : "0");
 
 	if (options & NOTIFICATION_OPTION_BROADCAST)
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This notification will be BROADCAST to all (escalated and normal) contacts...\n");
@@ -2106,8 +2103,7 @@ int add_notification(nagios_macros *mac, contact *cntct)
 		return OK;
 
 	/* allocate memory for a new contact in the notification list */
-	if ((new_notification = malloc(sizeof(notification))) == NULL)
-		return ERROR;
+	new_notification = nm_malloc(sizeof(notification));
 
 	/* fill in the contact info */
 	new_notification->contact = cntct;
@@ -2118,12 +2114,11 @@ int add_notification(nagios_macros *mac, contact *cntct)
 
 	/* add contact to notification recipients macro */
 	if (mac->x[MACRO_NOTIFICATIONRECIPIENTS] == NULL)
-		mac->x[MACRO_NOTIFICATIONRECIPIENTS] = (char *)strdup(cntct->name);
+		mac->x[MACRO_NOTIFICATIONRECIPIENTS] = nm_strdup(cntct->name);
 	else {
-		if ((mac->x[MACRO_NOTIFICATIONRECIPIENTS] = (char *)realloc(mac->x[MACRO_NOTIFICATIONRECIPIENTS], strlen(mac->x[MACRO_NOTIFICATIONRECIPIENTS]) + strlen(cntct->name) + 2))) {
-			strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], ",");
-			strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], cntct->name);
-		}
+		mac->x[MACRO_NOTIFICATIONRECIPIENTS] = nm_realloc(mac->x[MACRO_NOTIFICATIONRECIPIENTS], strlen(mac->x[MACRO_NOTIFICATIONRECIPIENTS]) + strlen(cntct->name) + 2);
+		strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], ",");
+		strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], cntct->name);
 	}
 
 	return OK;

--- a/naemon/objects.c
+++ b/naemon/objects.c
@@ -5,6 +5,7 @@
 #include "xodtemplate.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 
 
 /*
@@ -152,8 +153,8 @@ static void post_process_object_config(void)
 	if (servicedependency_ary)
 		free(servicedependency_ary);
 
-	hostdependency_ary = calloc(num_objects.hostdependencies, sizeof(void *));
-	servicedependency_ary = calloc(num_objects.servicedependencies, sizeof(void *));
+	hostdependency_ary = nm_calloc(num_objects.hostdependencies, sizeof(void *));
+	servicedependency_ary = nm_calloc(num_objects.servicedependencies, sizeof(void *));
 
 	slot = 0;
 	for (i = 0; slot < num_objects.servicedependencies && i < num_objects.services; i++) {
@@ -279,7 +280,7 @@ static int create_object_table(const char *name, unsigned int elems, unsigned in
 		*ptr = NULL;
 		return OK;
 	}
-	ret = calloc(elems, size);
+	ret = nm_calloc(elems, size);
 	if (!ret) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to allocate %s table with %u elements\n", name, elems);
 		return ERROR;
@@ -351,9 +352,7 @@ timeperiod *add_timeperiod(char *name, char *alias)
 		return NULL;
 	}
 
-	new_timeperiod = calloc(1, sizeof(*new_timeperiod));
-	if (!new_timeperiod)
-		return NULL;
+	new_timeperiod = nm_calloc(1, sizeof(*new_timeperiod));
 
 	/* copy string vars */
 	new_timeperiod->name = name;
@@ -400,10 +399,8 @@ timeperiodexclusion *add_exclusion_to_timeperiod(timeperiod *period, char *name)
 	if (period == NULL || name == NULL)
 		return NULL;
 
-	if ((new_timeperiodexclusion = (timeperiodexclusion *)malloc(sizeof(timeperiodexclusion))) == NULL)
-		return NULL;
-
-	new_timeperiodexclusion->timeperiod_name = (char *)strdup(name);
+	new_timeperiodexclusion = nm_malloc(sizeof(timeperiodexclusion));
+	new_timeperiodexclusion->timeperiod_name = nm_strdup(name);
 
 	new_timeperiodexclusion->next = period->exclusions;
 	period->exclusions = new_timeperiodexclusion;
@@ -435,9 +432,7 @@ timerange *add_timerange_to_timeperiod(timeperiod *period, int day, unsigned lon
 	}
 
 	/* allocate memory for the new time range */
-	if ((new_timerange = malloc(sizeof(timerange))) == NULL)
-		return NULL;
-
+	new_timerange = nm_malloc(sizeof(timerange));
 	new_timerange->range_start = start_time;
 	new_timerange->range_end = end_time;
 
@@ -476,9 +471,7 @@ daterange *add_exception_to_timeperiod(timeperiod *period, int type, int syear, 
 		return NULL;
 
 	/* allocate memory for the date range range */
-	if ((new_daterange = malloc(sizeof(daterange))) == NULL)
-		return NULL;
-
+	new_daterange = nm_malloc(sizeof(daterange));
 	new_daterange->times = NULL;
 	new_daterange->next = NULL;
 
@@ -522,9 +515,7 @@ timerange *add_timerange_to_daterange(daterange *drange, unsigned long start_tim
 	}
 
 	/* allocate memory for the new time range */
-	if ((new_timerange = malloc(sizeof(timerange))) == NULL)
-		return NULL;
-
+	new_timerange = nm_malloc(sizeof(timerange));
 	new_timerange->range_start = start_time;
 	new_timerange->range_end = end_time;
 
@@ -581,7 +572,7 @@ host *add_host(char *name, char *display_name, char *alias, char *address, char 
 		return NULL;
 	}
 
-	new_host = calloc(1, sizeof(*new_host));
+	new_host = nm_calloc(1, sizeof(*new_host));
 
 	/* assign string vars */
 	new_host->name = name;
@@ -693,12 +684,9 @@ hostsmember *add_parent_host_to_host(host *hst, char *host_name)
 	}
 
 	/* allocate memory */
-	if ((new_hostsmember = (hostsmember *)calloc(1, sizeof(hostsmember))) == NULL)
-		return NULL;
-
+	new_hostsmember = nm_calloc(1, sizeof(hostsmember));
 	/* duplicate string vars */
-	if ((new_hostsmember->host_name = (char *)strdup(host_name)) == NULL)
-		result = ERROR;
+	new_hostsmember->host_name = nm_strdup(host_name);
 
 	/* handle errors */
 	if (result == ERROR) {
@@ -722,16 +710,9 @@ servicesmember *add_parent_service_to_service(service *svc, char *host_name, cha
 	if (!svc || !host_name || !description || !*host_name || !*description)
 		return NULL;
 
-	if ((sm = calloc(1, sizeof(*sm))) == NULL)
-		return NULL;
+	sm = nm_calloc(1, sizeof(*sm));
 
-	if ((sm->host_name = strdup(host_name)) == NULL || (sm->service_description = strdup(description)) == NULL) {
-		/* there was an error copying (description is NULL now) */
-		my_free(sm->host_name);
-		free(sm);
-		return NULL;
-	}
-
+	sm->host_name = nm_strdup(host_name);
 	sm->next = svc->parents;
 	svc->parents = sm;
 	return sm;
@@ -747,8 +728,7 @@ hostsmember *add_child_link_to_host(host *hst, host *child_ptr)
 		return NULL;
 
 	/* allocate memory */
-	if ((new_hostsmember = (hostsmember *)malloc(sizeof(hostsmember))) == NULL)
-		return NULL;
+	new_hostsmember = nm_malloc(sizeof(hostsmember));
 
 	/* assign values */
 	new_hostsmember->host_name = child_ptr->name;
@@ -771,9 +751,7 @@ servicesmember *add_service_link_to_host(host *hst, service *service_ptr)
 		return NULL;
 
 	/* allocate memory */
-	if ((new_servicesmember = (servicesmember *)calloc(1, sizeof(servicesmember))) == NULL)
-		return NULL;
-
+	new_servicesmember = nm_calloc(1, sizeof(servicesmember));
 	/* assign values */
 	new_servicesmember->host_name = service_ptr->host_name;
 	new_servicesmember->service_description = service_ptr->description;
@@ -802,10 +780,7 @@ static contactgroupsmember *add_contactgroup_to_object(contactgroupsmember **cg_
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup '%s' is not defined anywhere\n", group_name);
 		return NULL;
 	}
-	if (!(cgm = malloc(sizeof(*cgm)))) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for contactgroup\n");
-		return NULL;
-	}
+	cgm = nm_malloc(sizeof(*cgm));
 	cgm->group_name = cg->group_name;
 	cgm->group_ptr = cg;
 	cgm->next = *cg_list;
@@ -850,7 +825,7 @@ hostgroup *add_hostgroup(char *name, char *alias, char *notes, char *notes_url, 
 		return NULL;
 	}
 
-	new_hostgroup = calloc(1, sizeof(*new_hostgroup));
+	new_hostgroup = nm_calloc(1, sizeof(*new_hostgroup));
 
 	/* assign vars */
 	new_hostgroup->group_name = name;
@@ -910,9 +885,7 @@ hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name)
 	}
 
 	/* allocate memory for a new member */
-	if ((new_member = calloc(1, sizeof(hostsmember))) == NULL)
-		return NULL;
-
+	new_member = nm_calloc(1, sizeof(hostsmember));
 	/* assign vars */
 	new_member->host_name = h->name;
 	new_member->host_ptr = h;
@@ -962,7 +935,7 @@ servicegroup *add_servicegroup(char *name, char *alias, char *notes, char *notes
 		return NULL;
 	}
 
-	new_servicegroup = calloc(1, sizeof(*new_servicegroup));
+	new_servicegroup = nm_calloc(1, sizeof(*new_servicegroup));
 
 	/* duplicate vars */
 	new_servicegroup->group_name = name;
@@ -1022,8 +995,7 @@ servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, cha
 	}
 
 	/* allocate memory for a new member */
-	if ((new_member = calloc(1, sizeof(servicesmember))) == NULL)
-		return NULL;
+	new_member = nm_calloc(1, sizeof(servicesmember));
 
 	/* assign vars */
 	new_member->host_name = svc->host_name;
@@ -1104,10 +1076,7 @@ contact *add_contact(char *name, char *alias, char *email, char *pager, char **a
 	}
 
 
-	new_contact = calloc(1, sizeof(*new_contact));
-	if (!new_contact)
-		return NULL;
-
+	new_contact = nm_calloc(1, sizeof(*new_contact));
 	new_contact->host_notification_period = htp ? htp->name : NULL;
 	new_contact->service_notification_period = stp ? stp->name : NULL;
 	new_contact->host_notification_period_ptr = htp;
@@ -1175,12 +1144,10 @@ commandsmember *add_host_notification_command_to_contact(contact *cntct, char *c
 	}
 
 	/* allocate memory */
-	if ((new_commandsmember = calloc(1, sizeof(commandsmember))) == NULL)
-		return NULL;
+	new_commandsmember = nm_calloc(1, sizeof(commandsmember));
 
 	/* duplicate vars */
-	if ((new_commandsmember->command = (char *)strdup(command_name)) == NULL)
-		result = ERROR;
+	new_commandsmember->command = nm_strdup(command_name);
 
 	/* handle errors */
 	if (result == ERROR) {
@@ -1210,12 +1177,10 @@ commandsmember *add_service_notification_command_to_contact(contact *cntct, char
 	}
 
 	/* allocate memory */
-	if ((new_commandsmember = calloc(1, sizeof(commandsmember))) == NULL)
-		return NULL;
+	new_commandsmember = nm_calloc(1, sizeof(commandsmember));
 
 	/* duplicate vars */
-	if ((new_commandsmember->command = (char *)strdup(command_name)) == NULL)
-		result = ERROR;
+	new_commandsmember->command = nm_strdup(command_name);
 
 	/* handle errors */
 	if (result == ERROR) {
@@ -1252,9 +1217,7 @@ contactgroup *add_contactgroup(char *name, char *alias)
 		return NULL;
 	}
 
-	new_contactgroup = calloc(1, sizeof(*new_contactgroup));
-	if (!new_contactgroup)
-		return NULL;
+	new_contactgroup = nm_calloc(1, sizeof(*new_contactgroup));
 
 	/* assign vars */
 	new_contactgroup->group_name = name;
@@ -1310,8 +1273,7 @@ contactsmember *add_contact_to_contactgroup(contactgroup *grp, char *contact_nam
 	}
 
 	/* allocate memory for a new member */
-	if ((new_contactsmember = calloc(1, sizeof(contactsmember))) == NULL)
-		return NULL;
+	new_contactsmember = nm_calloc(1, sizeof(contactsmember));
 
 	/* assign vars */
 	new_contactsmember->contact_name = c->name;
@@ -1387,9 +1349,7 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	}
 
 	/* allocate memory */
-	new_service = calloc(1, sizeof(*new_service));
-	if (!new_service)
-		return NULL;
+	new_service = nm_calloc(1, sizeof(*new_service));
 
 	/* duplicate vars, but assign what we can */
 	new_service->notification_period_ptr = np;
@@ -1398,39 +1358,30 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	new_service->check_period = cp ? cp->name : NULL;
 	new_service->notification_period = np ? np->name : NULL;
 	new_service->host_name = h->name;
-	if ((new_service->description = (char *)strdup(description)) == NULL)
-		result = ERROR;
+	new_service->description = nm_strdup(description);
 	if (display_name) {
-		if ((new_service->display_name = (char *)strdup(display_name)) == NULL)
-			result = ERROR;
+		new_service->display_name = nm_strdup(display_name);
 	} else {
 		new_service->display_name = new_service->description;
 	}
-	if ((new_service->check_command = (char *)strdup(check_command)) == NULL)
-		result = ERROR;
+	new_service->check_command = nm_strdup(check_command);
 	if (event_handler) {
-		if ((new_service->event_handler = (char *)strdup(event_handler)) == NULL)
-			result = ERROR;
+		new_service->event_handler = nm_strdup(event_handler);
 	}
 	if (notes) {
-		if ((new_service->notes = (char *)strdup(notes)) == NULL)
-			result = ERROR;
+		new_service->notes = nm_strdup(notes);
 	}
 	if (notes_url) {
-		if ((new_service->notes_url = (char *)strdup(notes_url)) == NULL)
-			result = ERROR;
+		new_service->notes_url = nm_strdup(notes_url);
 	}
 	if (action_url) {
-		if ((new_service->action_url = (char *)strdup(action_url)) == NULL)
-			result = ERROR;
+		new_service->action_url = nm_strdup(action_url);
 	}
 	if (icon_image) {
-		if ((new_service->icon_image = (char *)strdup(icon_image)) == NULL)
-			result = ERROR;
+		new_service->icon_image = nm_strdup(icon_image);
 	}
 	if (icon_image_alt) {
-		if ((new_service->icon_image_alt = (char *)strdup(icon_image_alt)) == NULL)
-			result = ERROR;
+		new_service->icon_image_alt = nm_strdup(icon_image_alt);
 	}
 
 	new_service->hourly_value = hourly_value;
@@ -1543,9 +1494,7 @@ command *add_command(char *name, char *value)
 	}
 
 	/* allocate memory for the new command */
-	new_command = calloc(1, sizeof(*new_command));
-	if (!new_command)
-		return NULL;
+	new_command = nm_calloc(1, sizeof(*new_command));
 
 	/* assign vars */
 	new_command->name = name;
@@ -1606,9 +1555,7 @@ serviceescalation *add_serviceescalation(char *host_name, char *description, int
 		return NULL ;
 	}
 
-	new_serviceescalation = calloc(1, sizeof(*new_serviceescalation));
-	if (!new_serviceescalation)
-		return NULL;
+	new_serviceescalation = nm_calloc(1, sizeof(*new_serviceescalation));
 
 	if (prepend_object_to_objectlist(&svc->escalation_list, new_serviceescalation) != OK) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Could not add escalation to service '%s' on host '%s'\n",
@@ -1677,8 +1624,7 @@ servicedependency *add_service_dependency(char *dependent_host_name, char *depen
 	}
 
 	/* allocate memory for a new service dependency entry */
-	if ((new_servicedependency = calloc(1, sizeof(*new_servicedependency))) == NULL)
-		return NULL;
+	new_servicedependency = nm_calloc(1, sizeof(*new_servicedependency));
 
 	new_servicedependency->dependent_service_ptr = child;
 	new_servicedependency->master_service_ptr = parent;
@@ -1745,9 +1691,7 @@ hostdependency *add_host_dependency(char *dependent_host_name, char *host_name, 
 		return NULL ;
 	}
 
-	if ((new_hostdependency = calloc(1, sizeof(*new_hostdependency))) == NULL)
-		return NULL;
-
+	new_hostdependency = nm_calloc(1, sizeof(*new_hostdependency));
 	new_hostdependency->dependent_host_ptr = child;
 	new_hostdependency->master_host_ptr = parent;
 	new_hostdependency->dependency_period_ptr = tp;
@@ -1800,7 +1744,7 @@ hostescalation *add_hostescalation(char *host_name, int first_notification, int 
 		return NULL;
 	}
 
-	new_hostescalation = calloc(1, sizeof(*new_hostescalation));
+	new_hostescalation = nm_calloc(1, sizeof(*new_hostescalation));
 
 	/* add the escalation to its host */
 	if (prepend_object_to_objectlist(&h->escalation_list, new_hostescalation) != OK) {
@@ -1862,10 +1806,7 @@ contactsmember *add_contact_to_object(contactsmember **object_ptr, char *contact
 	}
 
 	/* allocate memory for a new member */
-	if ((new_contactsmember = malloc(sizeof(contactsmember))) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for contact\n");
-		return NULL;
-	}
+	new_contactsmember = nm_malloc(sizeof(contactsmember));
 	new_contactsmember->contact_name = c->name;
 
 	/* set initial values */
@@ -1896,23 +1837,11 @@ customvariablesmember *add_custom_variable_to_object(customvariablesmember **obj
 	}
 
 	/* allocate memory for a new member */
-	if ((new_customvariablesmember = malloc(sizeof(customvariablesmember))) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable\n");
-		return NULL;
-	}
-	if ((new_customvariablesmember->variable_name = (char *)strdup(varname)) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable name\n");
-		my_free(new_customvariablesmember);
-		return NULL;
-	}
-	if (varvalue) {
-		if ((new_customvariablesmember->variable_value = (char *)strdup(varvalue)) == NULL) {
-			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable value\n");
-			my_free(new_customvariablesmember->variable_name);
-			my_free(new_customvariablesmember);
-			return NULL;
-		}
-	} else
+	new_customvariablesmember = nm_malloc(sizeof(customvariablesmember));
+	new_customvariablesmember->variable_name = nm_strdup(varname);
+	if (varvalue)
+		new_customvariablesmember->variable_value = nm_strdup(varvalue);
+	else
 		new_customvariablesmember->variable_value = NULL;
 
 	/* set initial values */
@@ -2007,9 +1936,7 @@ int add_object_to_objectlist(objectlist **list, void *object_ptr)
 		return OK;
 
 	/* allocate memory for a new list item */
-	if ((new_item = (objectlist *)malloc(sizeof(objectlist))) == NULL)
-		return ERROR;
-
+	new_item = nm_malloc(sizeof(objectlist));
 	/* initialize vars */
 	new_item->object_ptr = object_ptr;
 
@@ -2027,8 +1954,7 @@ int prepend_object_to_objectlist(objectlist **list, void *object_ptr)
 	objectlist *item;
 	if (list == NULL || object_ptr == NULL)
 		return ERROR;
-	if ((item = malloc(sizeof(*item))) == NULL)
-		return ERROR;
+	item = nm_malloc(sizeof(*item));
 	item->next = *list;
 	item->object_ptr = object_ptr;
 	*list = item;

--- a/naemon/oconfsplit.c
+++ b/naemon/oconfsplit.c
@@ -23,6 +23,7 @@
 #include "nebmods.h"
 #include "nebmodules.h"
 #include "workers.h"
+#include "nm_alloc.h"
 #include <string.h>
 #include <stdarg.h>
 #include <getopt.h>
@@ -315,7 +316,7 @@ static int nsplit_cache_stuff(const char *orig_groups)
 	if (!orig_groups)
 		return EXIT_FAILURE;
 
-	grp = groups = strdup(orig_groups);
+	grp = groups = nm_strdup(orig_groups);
 	for (grp = groups; grp != NULL; grp = comma ? comma + 1 : NULL) {
 		if ((comma = strchr(grp, ',')))
 			* comma = 0;
@@ -405,7 +406,7 @@ int main(int argc, char **argv)
 #define getopt(a, b, c) getopt_long(a, b, c, long_options, &option_index)
 #endif
 
-	self_name = strdup(basename(argv[0]));
+	self_name = nm_strdup(basename(argv[0]));
 	/* make sure we have the correct number of command line arguments */
 	if (argc < 2) {
 		usage("Not enough arguments.\n");
@@ -467,7 +468,7 @@ int main(int argc, char **argv)
 
 	if (!config_file) {
 		if (optind >= argc)
-			config_file = strdup(get_default_config_file());
+			config_file = nm_strdup(get_default_config_file());
 		else
 			config_file = argv[optind];
 	}

--- a/naemon/query-handler.c
+++ b/naemon/query-handler.c
@@ -8,6 +8,7 @@
 #include "loadctl.h"
 #include "globals.h"
 #include "commands.h"
+#include "nm_alloc.h"
 #include <unistd.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -263,11 +264,7 @@ int qh_register_handler(const char *name, const char *description, unsigned int 
 		return -1;
 	}
 
-	if (!(qh = calloc(1, sizeof(*qh)))) {
-		logit(NSLOG_RUNTIME_ERROR, TRUE, "qh: Failed to allocate memory for handler '%s'\n", name);
-		return -errno;
-	}
-
+	qh = nm_calloc(1, sizeof(*qh));
 	qh->name = name;
 	qh->description = description;
 	qh->handler = handler;

--- a/naemon/sehandlers.c
+++ b/naemon/sehandlers.c
@@ -11,6 +11,7 @@
 #include "utils.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 #ifdef USE_EVENT_BROKER
@@ -95,16 +96,12 @@ int obsessive_compulsive_service_check_processor(service *svc)
 	log_debug_info(DEBUGL_CHECKS, 2, "Processed obsessive compulsive service processor command line: %s\n", processed_command);
 
 	/* run the command through a worker */
-	ocj = (struct obsessive_compulsive_job*)calloc(1,sizeof(struct obsessive_compulsive_job));
-	if(ocj == NULL) {
-		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Allocating storage for OCSP job\n");
-	} else {
-		ocj->hst = svc->host_ptr;
-		ocj->svc = svc;
-		if(ERROR == wproc_run_callback(processed_command, ocsp_timeout, obsessive_compulsive_job_handler, ocj, &mac)) {
-			logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to start OCSP job for service '%s on host '%s' to worker\n", svc->description, svc->host_ptr->name);
-			free(ocj);
-		}
+	ocj = nm_calloc(1,sizeof(struct obsessive_compulsive_job));
+	ocj->hst = svc->host_ptr;
+	ocj->svc = svc;
+	if(ERROR == wproc_run_callback(processed_command, ocsp_timeout, obsessive_compulsive_job_handler, ocj, &mac)) {
+		logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to start OCSP job for service '%s on host '%s' to worker\n", svc->description, svc->host_ptr->name);
+		free(ocj);
 	}
 
 	/* free memory */
@@ -161,16 +158,12 @@ int obsessive_compulsive_host_check_processor(host *hst)
 	log_debug_info(DEBUGL_CHECKS, 2, "Processed obsessive compulsive host processor command line: %s\n", processed_command);
 
 	/* run the command through a worker */
-	ocj = (struct obsessive_compulsive_job*)calloc(1,sizeof(struct obsessive_compulsive_job));
-	if(ocj == NULL) {
-		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Allocating storage for OCHP job\n");
-	} else {
-		ocj->hst = hst;
-		ocj->svc = NULL;
-		if(ERROR == wproc_run_callback(processed_command, ochp_timeout, obsessive_compulsive_job_handler, ocj, &mac)) {
-			logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to start OCHP job for host '%s' to worker\n", hst->name);
-			free(ocj);
-		}
+	ocj = nm_calloc(1,sizeof(struct obsessive_compulsive_job));
+	ocj->hst = hst;
+	ocj->svc = NULL;
+	if(ERROR == wproc_run_callback(processed_command, ochp_timeout, obsessive_compulsive_job_handler, ocj, &mac)) {
+		logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to start OCHP job for host '%s' to worker\n", hst->name);
+		free(ocj);
 	}
 
 	/* free memory */
@@ -295,7 +288,7 @@ int run_global_service_event_handler(nagios_macros *mac, service *svc)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 2, "Processed global service event handler command line: %s\n", processed_command);
 
 	if (log_event_handlers == TRUE) {
-		asprintf(&raw_logentry, "GLOBAL SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, global_service_event_handler);
+		nm_asprintf(&raw_logentry, "GLOBAL SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, global_service_event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
 	}
@@ -394,7 +387,7 @@ int run_service_event_handler(nagios_macros *mac, service *svc)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 2, "Processed service event handler command line: %s\n", processed_command);
 
 	if (log_event_handlers == TRUE) {
-		asprintf(&raw_logentry, "SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, svc->event_handler);
+		nm_asprintf(&raw_logentry, "SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, svc->event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
 	}
@@ -536,7 +529,7 @@ int run_global_host_event_handler(nagios_macros *mac, host *hst)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 2, "Processed global host event handler command line: %s\n", processed_command);
 
 	if (log_event_handlers == TRUE) {
-		asprintf(&raw_logentry, "GLOBAL HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, global_host_event_handler);
+		nm_asprintf(&raw_logentry, "GLOBAL HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, global_host_event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
 	}
@@ -634,7 +627,7 @@ int run_host_event_handler(nagios_macros *mac, host *hst)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 2, "Processed host event handler command line: %s\n", processed_command);
 
 	if (log_event_handlers == TRUE) {
-		asprintf(&raw_logentry, "HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, hst->event_handler);
+		nm_asprintf(&raw_logentry, "HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, hst->event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
 	}

--- a/naemon/shadownaemon.c
+++ b/naemon/shadownaemon.c
@@ -6,6 +6,7 @@
  */
 
 #include "shadownaemon.h"
+#include "nm_alloc.h"
 #include <libgen.h>
 
 static int verbose                         = FALSE;
@@ -96,7 +97,7 @@ int main(int argc, char **argv) {
 #define getopt(a, b, c) getopt_long(a, b, c, long_options, &option_index)
 #endif
 
-    self_name = strdup(basename(argv[0]));
+    self_name = nm_strdup(basename(argv[0]));
     shadow_program_restart = time(NULL);
 
     enable_timing_point = 0;
@@ -159,21 +160,21 @@ int main(int argc, char **argv) {
 
     /* required before daemonizing, because we need full pid path */
     my_free(output_socket_path);
-    output_socket_path = malloc(sizeof(char) * 250);
+    output_socket_path = nm_malloc(250);
     snprintf(output_socket_path, 249, "%s/%s", output_folder, "live");
     output_folder   = nspath_absolute_dirname(output_socket_path, NULL);
     config_file_dir = nspath_absolute_dirname(output_socket_path, NULL);
     my_free(tmp_folder);
-    tmp_folder = malloc(sizeof(char) * 250);
+    tmp_folder = nm_malloc(250);
     snprintf(tmp_folder, 249, "%s/%s", output_folder, "tmp");
     nspath_mkdir_p(output_folder, 0700, 0);
     nspath_mkdir_p(tmp_folder, 0700, 0);
     my_free(log_file);
-    log_file = malloc(sizeof(char) * 250);
+    log_file = nm_malloc(250);
     snprintf(log_file, 249, "%s/%s", tmp_folder, "shadownaemon.log");
 
     if(daemonmode == TRUE) {
-        lock_file = malloc(sizeof(char) * 250);
+        lock_file = nm_malloc(250);
         snprintf(lock_file, 249, "%s/shadownaemon.pid", tmp_folder);
         // daemon init changes to wrong folder otherwise
 #ifdef HAVE_GET_CURRENT_DIR_NAME
@@ -185,10 +186,7 @@ int main(int argc, char **argv) {
             size_t size = 50;
             errno = 0;
             do {
-                cwd = malloc(size);
-                if (!cwd) {
-                    goto error_out;
-                }
+                cwd = nm_malloc(size);
                 if (getcwd(cwd, size) == cwd) {
                     break;
                 }
@@ -273,7 +271,7 @@ error_out:
 
 /* return path to default livestatus */
 char *get_default_livestatus_module() {
-    char *livestatus_path = malloc(sizeof(char) * 250);
+    char *livestatus_path = nm_malloc(250);
     struct stat st;
 
     snprintf(livestatus_path, 249, "%s/lib/naemon/naemon-livestatus/livestatus.so", getenv("HOME"));
@@ -334,30 +332,30 @@ int write_config_files() {
     /* set our file locations */
     config_file_dir = nspath_absolute_dirname(output_socket_path, NULL);
     my_free(config_file);
-    config_file = malloc(sizeof(char) * 250);
+    config_file = nm_malloc(250);
     snprintf(config_file, 249, "%s/%s", tmp_folder, "naemon.cfg");
     my_free(resource_config);
-    resource_config = malloc(sizeof(char) * 250);
+    resource_config = nm_malloc(250);
     snprintf(resource_config, 249, "%s/%s", tmp_folder, "resource.cfg");
     my_free(objects_file);
-    objects_file = malloc(sizeof(char) * 250);
+    objects_file = nm_malloc(250);
     snprintf(objects_file, 249, "%s/%s", tmp_folder, "objects.cfg");
     my_free(retention_file);
-    retention_file = malloc(sizeof(char) * 250);
+    retention_file = nm_malloc(250);
     snprintf(retention_file, 249, "%s/%s", tmp_folder, "retention.dat");
     my_free(livestatus_log);
-    livestatus_log = malloc(sizeof(char) * 250);
+    livestatus_log = nm_malloc(250);
     snprintf(livestatus_log, 249, "%s/%s", tmp_folder, "livestatus.log");
     my_free(check_result_path);
-    check_result_path = strdup(tmp_folder);
+    check_result_path = nm_strdup(tmp_folder);
     my_free(log_file);
-    log_file = malloc(sizeof(char) * 250);
+    log_file = nm_malloc(250);
     snprintf(log_file, 249, "%s/%s", tmp_folder, "shadownaemon.log");
     my_free(cmds_pattern);
-    cmds_pattern = malloc(sizeof(char) * 250);
+    cmds_pattern = nm_malloc(250);
     snprintf(cmds_pattern, 249, "%s/*.cmds", tmp_folder);
     my_free(archive_folder);
-    archive_folder = malloc(sizeof(char) * 250);
+    archive_folder = nm_malloc(250);
     snprintf(archive_folder, 249, "%s/%s", tmp_folder, "archives");
 
     if(should_write_config == FALSE) {
@@ -661,7 +659,7 @@ int livestatus_query_socket(result_list **result, char *socket_path, char *query
     for(x=0; x<columnssize; x++)
         columnslength += strlen(columns[x]);
     columnslength += 20 + columnssize;
-    columnsheader = malloc(sizeof(char) * columnslength);
+    columnsheader = nm_malloc(columnslength);
     columnsheader[0] = '\0';
     strcat(columnsheader, "Columns: ");
     for(x=0; x<columnssize; x++) {
@@ -703,7 +701,7 @@ int livestatus_query_socket(result_list **result, char *socket_path, char *query
         return(row_size);
     }
 
-    result_string   = malloc(sizeof(char*)*result_size+1);
+    result_string   = nm_malloc(sizeof(char*)*result_size+1);
     result_string_c = result_string;
     total_read      = 0;
     size            = 0;
@@ -726,14 +724,14 @@ int livestatus_query_socket(result_list **result, char *socket_path, char *query
     while((ptr = strsep( &result_string, "\x1")) != NULL) {
         if(!strcmp(ptr, "")) break;
         if(row_size > 0) {
-            curr->next = malloc(sizeof(result_list));
+            curr->next = nm_malloc(sizeof(result_list));
             curr = curr->next;
             curr->next = NULL;
         }
-        curr->set  = malloc(columnssize*sizeof(char*));
+        curr->set  = nm_malloc(columnssize*sizeof(char*));
         for(x=0;x<columnssize;x++) {
             cell = strsep( &ptr, "\x2");
-            curr->set[x] = strdup(cell);
+            curr->set[x] = nm_strdup(cell);
         }
         row_size++;
     }
@@ -800,7 +798,7 @@ int open_tcp_socket(char *connection_string) {
     tv.tv_sec  = 30;  /* 30 Secs Timeout */
     tv.tv_usec = 0;
 
-    server   = strdup(connection_string);
+    server   = nm_strdup(connection_string);
     server_c = server;
     hostname = strsep(&server, ":");
     port_val = strsep(&server, "\x0");
@@ -839,7 +837,7 @@ int open_tcp_socket(char *connection_string) {
 /* updates program status based on remote sites data */
 int update_program_status_data() {
     int num;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET status";
     char *columns[] = {"accept_passive_host_checks",        // 0
                        "accept_passive_service_checks",
@@ -923,7 +921,7 @@ int update_program_status_data() {
             process_performance_data        = atoi(answer->set[14]);
             program_start                   = atoi(answer->set[15]);
             if(program_version == NULL)
-                program_version             = strdup(answer->set[16]);
+                program_version             = nm_strdup(answer->set[16]);
             interval_length                 = atoi(answer->set[17]);
 
             /* update livestatus counter */
@@ -976,7 +974,7 @@ int update_host_status_data() {
     int num, running, len;
     host *hst = NULL;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query  = "GET hosts";
     char *filtered_query;
     char *columns[] = {"name",                          // 0
@@ -1017,7 +1015,7 @@ int update_host_status_data() {
     int columns_size = sizeof(columns)/sizeof(columns[0]);
 
     /* add filter by last_refresh and is_executing and all our hosts which are marked as currently running */
-    filtered_query = malloc(sizeof(char) * 50 * get_host_count());
+    filtered_query = nm_calloc(get_host_count(), 50);
     len = sprintf(filtered_query, "%s\nFilter: is_executing = 1\nFilter: last_check >= %d\nOr: 2\n", query, (int)last_refresh);
 
     /* linear search to get all hosts currently running */
@@ -1038,7 +1036,7 @@ int update_host_status_data() {
     /* too many running hosts would blow off our filter, so just fetch everything if we hit the limit */
     if(full_refresh_required || running > max_number_of_executing_objects) {
         my_free(filtered_query);
-        filtered_query = strdup(query);
+        filtered_query = nm_strdup(query);
     }
     num = livestatus_query(&answer, (char*)input_source, filtered_query, columns, columns_size);
     my_free(filtered_query);
@@ -1069,15 +1067,15 @@ int update_host_status_data() {
             hst->last_state_change              = atoi(row->set[15]);
             hst->latency                        = atof(row->set[16]);
             my_free(hst->long_plugin_output);
-            hst->long_plugin_output             = strdup(row->set[17]);
+            hst->long_plugin_output             = nm_strdup(row->set[17]);
             hst->next_check                     = atoi(row->set[18]);
             hst->notifications_enabled          = atoi(row->set[19]);
             hst->obsess                         = atoi(row->set[20]);
             hst->percent_state_change           = atoi(row->set[21]);
             my_free(hst->perf_data);
-            hst->perf_data                      = strdup(row->set[22]);
+            hst->perf_data                      = nm_strdup(row->set[22]);
             my_free(hst->plugin_output);
-            hst->plugin_output                  = strdup(row->set[23]);
+            hst->plugin_output                  = nm_strdup(row->set[23]);
             hst->process_performance_data       = atoi(row->set[24]);
             hst->scheduled_downtime_depth       = atoi(row->set[25]);
             hst->current_state                  = atoi(row->set[26]);
@@ -1105,7 +1103,7 @@ int update_service_status_data() {
     int num, running, len;
     service *svc = NULL;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query  = "GET services";
     char *filtered_query;
     char *columns[] = {"host_name",                     // 0
@@ -1148,7 +1146,7 @@ int update_service_status_data() {
     int columns_size = sizeof(columns)/sizeof(columns[0]);
 
     /* add filter by last_refresh and is_executing and all our services which are marked as currently running */
-    filtered_query = malloc(sizeof(char) * 50 * get_service_count());
+    filtered_query = nm_calloc(get_service_count(), 50);
     len = sprintf(filtered_query, "%s\nFilter: is_executing = 1\nFilter: last_check >= %d\nOr: 2\n", query, (int)last_refresh);
 
     /* linear search to get all services currently running */
@@ -1169,7 +1167,7 @@ int update_service_status_data() {
     /* too many running services would blow off our filter, so just fetch everything if we hit the limit */
     if(full_refresh_required || running > max_number_of_executing_objects) {
         my_free(filtered_query);
-        filtered_query = strdup(query);
+        filtered_query = nm_strdup(query);
     }
     num = livestatus_query(&answer, (char*)input_source, filtered_query, columns, columns_size);
     my_free(filtered_query);
@@ -1199,15 +1197,15 @@ int update_service_status_data() {
             svc->last_state_change              = atoi(row->set[16]);
             svc->latency                        = atof(row->set[17]);
             my_free(svc->long_plugin_output);
-            svc->long_plugin_output             = strdup(row->set[18]);
+            svc->long_plugin_output             = nm_strdup(row->set[18]);
             svc->next_check                     = atoi(row->set[19]);
             svc->notifications_enabled          = atoi(row->set[20]);
             svc->obsess                         = atoi(row->set[21]);
             svc->percent_state_change           = atoi(row->set[22]);
             my_free(svc->perf_data);
-            svc->perf_data                      = strdup(row->set[23]);
+            svc->perf_data                      = nm_strdup(row->set[23]);
             my_free(svc->plugin_output);
-            svc->plugin_output                  = strdup(row->set[24]);
+            svc->plugin_output                  = nm_strdup(row->set[24]);
             svc->process_performance_data       = atoi(row->set[25]);
             svc->scheduled_downtime_depth       = atoi(row->set[26]);
             svc->current_state                  = atoi(row->set[27]);
@@ -1252,7 +1250,7 @@ int update_downtime_data() {
     int num, result;
     unsigned long current_id;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     host *hst = NULL;
     service *svc = NULL;
     char *query  = "GET downtimes";
@@ -1273,7 +1271,7 @@ int update_downtime_data() {
     int columns_size = sizeof(columns)/sizeof(columns[0]);
 
     /* add filter by highest downtime id, we only need new ones */
-    filtered_query = malloc(sizeof(char) * 50 * get_service_count());
+    filtered_query = nm_calloc(get_service_count(), 50);
     sprintf(filtered_query, "%s\nFilter: id > %lu\n", query, highest_downtime_id);
 
     num = livestatus_query(&answer, (char*)input_source, filtered_query, columns, columns_size);
@@ -1348,7 +1346,7 @@ int remove_old_downtimes() {
     int num, result, removed, found;
     unsigned long current_id;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     scheduled_downtime *temp_downtime, *curr_downtime;
     host *hst = NULL;
     service *svc = NULL;
@@ -1412,7 +1410,7 @@ int update_comment_data() {
     int num, result;
     unsigned long current_id;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query  = "GET comments";
     char *filtered_query;
     char *columns[] = {"id",                            // 0
@@ -1430,7 +1428,7 @@ int update_comment_data() {
     int columns_size = sizeof(columns)/sizeof(columns[0]);
 
     /* add filter by highest comment id, we only need new ones */
-    filtered_query = malloc(sizeof(char) * 50 * get_service_count());
+    filtered_query = nm_calloc(get_service_count(), 50);
     sprintf(filtered_query, "%s\nFilter: id > %lu\n", query, highest_comment_id);
 
     num = livestatus_query(&answer, (char*)input_source, filtered_query, columns, columns_size);
@@ -1495,7 +1493,7 @@ int remove_old_comments() {
     int num, result, removed, found;
     unsigned long current_id;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     comment *temp_comment, *curr_comment;
     char *query  = "GET comments";
     char *columns[] = {"id"};
@@ -1662,7 +1660,7 @@ int run_refresh_loop() {
 int write_commands_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET commands";
     char *columns[] = {"name",
                        "line",
@@ -1673,7 +1671,7 @@ int write_commands_configuration(FILE *file) {
         row = answer;
         while(row != NULL) {
             if(dummy_command == NULL)
-                dummy_command = strdup(row->set[0]);
+                dummy_command = nm_strdup(row->set[0]);
             fprintf(file,"define command {\n");
             fprintf(file,"    command_name          %s\n",   row->set[0]);
             fprintf(file,"    command_line          %s\n\n", row->set[1]); /* extra new line ensures trailing backslashes don't break anything */
@@ -1693,7 +1691,7 @@ int write_commands_configuration(FILE *file) {
 int write_timeperiods_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET timeperiods";
     char *columns[] = {"name",
                        "alias",
@@ -1719,7 +1717,7 @@ int write_timeperiods_configuration(FILE *file) {
 int write_contactgroups_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET contactgroups";
     char *columns[] = {"name",
                        "alias",
@@ -1747,7 +1745,7 @@ int write_contactgroups_configuration(FILE *file) {
 int write_hostgroups_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET hostgroups";
     char *columns[] = {"name",
                        "alias",
@@ -1784,7 +1782,7 @@ int write_hostgroups_configuration(FILE *file) {
 int write_servicegroups_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET servicegroups";
     char *columns[] = {"name",
                        "alias",
@@ -1821,7 +1819,7 @@ int write_servicegroups_configuration(FILE *file) {
 int write_contacts_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET contacts";
     char *columns[] = {"name",
                        "alias",
@@ -1865,7 +1863,7 @@ int write_contacts_configuration(FILE *file) {
 int write_hosts_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET hosts";
     char *columns[] = {"name",                      // 0
                        "alias",
@@ -1940,7 +1938,7 @@ int write_hosts_configuration(FILE *file) {
 int write_services_configuration(FILE *file) {
     int num;
     result_list *row = NULL;
-    result_list *answer = malloc(sizeof(result_list));
+    result_list *answer = nm_malloc(sizeof(result_list));
     char *query = "GET services";
     char *columns[] = {"host_name",                 // 0
                        "description",
@@ -2014,7 +2012,7 @@ int write_list_attribute(FILE *file, char* attr, char* rawlist) {
     int i = -1;
     if(!strcmp(rawlist, ""))
         return(OK);
-    tmpstr = strdup(rawlist);
+    tmpstr = nm_strdup(rawlist);
     while(tmpstr[++i] != 0) {
         if(tmpstr[i] == 5 || tmpstr[i] == 6)
             tmpstr[i] = 44;
@@ -2029,8 +2027,8 @@ int write_custom_variables(FILE *file, char* rawnames, char* rawvalues) {
     char *names, *name, *namesp, *values, *value, *valuesp;
     if(!strcmp(rawnames, ""))
         return(OK);
-    names   = strdup(rawnames);
-    values  = strdup(rawvalues);
+    names   = nm_strdup(rawnames);
+    values  = nm_strdup(rawvalues);
     namesp  = names;
     valuesp = values;
     while((name = strsep(&names, "\x5")) != NULL) {

--- a/naemon/shared.c
+++ b/naemon/shared.c
@@ -1,6 +1,7 @@
 #include <config.h>
 #include "common.h"
 #include "defaults.h"
+#include "nm_alloc.h"
 #include <string.h>
 #include <stdarg.h>
 #include <sys/types.h>
@@ -88,8 +89,7 @@ char *my_strtok(char *buffer, const char *tokens)
 
 	if (buffer != NULL) {
 		my_free(original_my_strtok_buffer);
-		if ((my_strtok_buffer = (char *)strdup(buffer)) == NULL)
-			return NULL;
+		my_strtok_buffer = nm_strdup(buffer);
 		original_my_strtok_buffer = my_strtok_buffer;
 	}
 
@@ -167,8 +167,7 @@ mmapfile *mmap_fopen(const char *filename)
 		return NULL;
 
 	/* allocate memory */
-	if ((new_mmapfile = (mmapfile *) malloc(sizeof(mmapfile))) == NULL)
-		return NULL;
+	new_mmapfile = nm_malloc(sizeof(mmapfile));
 
 	/* open the file */
 	if ((fd = open(filename, mode)) == -1) {
@@ -201,7 +200,7 @@ mmapfile *mmap_fopen(const char *filename)
 		mmap_buf = NULL;
 
 	/* populate struct info for later use */
-	new_mmapfile->path = (char *)strdup(filename);
+	new_mmapfile->path = nm_strdup(filename);
 	new_mmapfile->fd = fd;
 	new_mmapfile->file_size = (unsigned long)file_size;
 	new_mmapfile->current_position = 0L;
@@ -265,9 +264,7 @@ char *mmap_fgets(mmapfile *temp_mmapfile)
 	len = (int)(x - temp_mmapfile->current_position);
 
 	/* allocate memory for the new line */
-	if ((buf = (char *)malloc(len + 1)) == NULL)
-		return NULL;
-
+	buf = nm_malloc(len + 1);
 	/* copy string to newly allocated memory and terminate the string */
 	memcpy(buf,
 	       ((char *)(temp_mmapfile->mmap_buf) +
@@ -306,8 +303,7 @@ char *mmap_fgets_multiline(mmapfile *temp_mmapfile)
 
 		if (buf == NULL) {
 			len = strlen(tempbuf);
-			if ((buf = (char *)malloc(len + 1)) == NULL)
-				break;
+			buf = nm_malloc(len + 1);
 			memcpy(buf, tempbuf, len);
 			buf[len] = '\x0';
 		} else {
@@ -317,9 +313,7 @@ char *mmap_fgets_multiline(mmapfile *temp_mmapfile)
 				stripped++;
 			len = strlen(stripped);
 			len2 = strlen(buf);
-			if ((buf =
-			         (char *)realloc(buf, len + len2 + 1)) == NULL)
-				break;
+			buf = nm_realloc(buf, len + len2 + 1);
 			strcat(buf, stripped);
 			len += len2;
 			buf[len] = '\x0';

--- a/naemon/sretention.c
+++ b/naemon/sretention.c
@@ -7,6 +7,7 @@
 #include "xrddefault.h"
 #include "globals.h"
 #include "logging.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 /* hosts and services before attribute modifications */
@@ -21,17 +22,9 @@ static struct contact **premod_contacts;
 /* initializes retention data at program start */
 int initialize_retention_data(const char *cfgfile)
 {
-	if (!(premod_hosts = calloc(sizeof(void *), num_objects.hosts)))
-		return ERROR;
-	if (!(premod_services = calloc(sizeof(void *), num_objects.services))) {
-		my_free(premod_hosts);
-		return ERROR;
-	}
-	if (!(premod_contacts = calloc(sizeof(void *), num_objects.contacts))) {
-		my_free(premod_hosts);
-		my_free(premod_services);
-		return ERROR;
-	}
+	premod_hosts = nm_calloc(num_objects.hosts, sizeof(void *));
+	premod_services = nm_calloc(num_objects.services, sizeof(void *));
+	premod_contacts = nm_calloc(num_objects.contacts, sizeof(void *));
 
 	return xrddefault_initialize_retention_data(cfgfile);
 }
@@ -117,7 +110,7 @@ int pre_modify_contact_attribute(struct contact *c, int attr)
 		return 0;
 	}
 
-	stash = malloc(sizeof(*stash));
+	stash = nm_malloc(sizeof(*stash));
 	memcpy(stash, c, sizeof(*stash));
 	premod_contacts[c->id] = stash;
 	return 0;
@@ -132,7 +125,7 @@ int pre_modify_service_attribute(struct service *s, int attr)
 		return 0;
 	}
 
-	stash = malloc(sizeof(*stash));
+	stash = nm_malloc(sizeof(*stash));
 	memcpy(stash, s, sizeof(*stash));
 	premod_services[s->id] = stash;
 	return 0;
@@ -147,7 +140,7 @@ int pre_modify_host_attribute(struct host *h, int attr)
 		return 0;
 	}
 
-	stash = malloc(sizeof(*stash));
+	stash = nm_malloc(sizeof(*stash));
 	memcpy(stash, h, sizeof(*stash));
 	premod_hosts[h->id] = stash;
 	return 0;

--- a/naemon/utils.c
+++ b/naemon/utils.c
@@ -15,6 +15,7 @@
 #include "logging.h"
 #include "defaults.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <assert.h>
 #include <limits.h>
 #include <sys/types.h>
@@ -543,7 +544,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 			output_dbuf.buf[max_output_length] = '\x0';
 
 		if (output != NULL && output_dbuf.buf)
-			*output = (char *)strdup(output_dbuf.buf);
+			*output = nm_strdup(output_dbuf.buf);
 
 	}
 
@@ -596,7 +597,7 @@ int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char
 	log_debug_info(DEBUGL_COMMANDS | DEBUGL_CHECKS | DEBUGL_MACROS, 2, "Raw Command Input: %s\n", cmd_ptr->command_line);
 
 	/* get the full command line */
-	*full_command = (char *)strdup((cmd_ptr->command_line == NULL) ? "" : cmd_ptr->command_line);
+	*full_command = nm_strdup((cmd_ptr->command_line == NULL) ? "" : cmd_ptr->command_line);
 
 	/* XXX: Crazy indent */
 	/* get the command arguments */
@@ -682,7 +683,7 @@ int set_environment_var(char *name, char *value, int set)
 #else
 		/* needed for Solaris and systems that don't have setenv() */
 		/* this will leak memory, but in a "controlled" way, since lost memory should be freed when the child process exits */
-		asprintf(&env_string, "%s=%s", name, (value == NULL) ? "" : value);
+		nm_asprintf(&env_string, "%s=%s", name, (value == NULL) ? "" : value);
 		if (env_string)
 			putenv(env_string);
 #endif
@@ -1854,7 +1855,7 @@ int process_check_result_queue(char *dirname)
 			}
 
 			/* can we find the associated ok-to-go file ? */
-			asprintf(&temp_buffer, "%s.ok", file);
+			nm_asprintf(&temp_buffer, "%s.ok", file);
 			result = stat(temp_buffer, &ok_stat_buf);
 			my_free(temp_buffer);
 			if (result == -1)
@@ -2000,9 +2001,9 @@ int process_check_result_file(char *fname)
 		/* else we have check result data */
 		else {
 			if (!strcmp(var, "host_name"))
-				cr.host_name = (char *)strdup(val);
+				cr.host_name = nm_strdup(val);
 			else if (!strcmp(var, "service_description")) {
-				cr.service_description = (char *)strdup(val);
+				cr.service_description = nm_strdup(val);
 				cr.object_check_type = SERVICE_CHECK;
 			} else if (!strcmp(var, "check_type"))
 				cr.check_type = atoi(val);
@@ -2035,7 +2036,7 @@ int process_check_result_file(char *fname)
 			else if (!strcmp(var, "return_code"))
 				cr.return_code = atoi(val);
 			else if (!strcmp(var, "output"))
-				cr.output = (char *)strdup(val);
+				cr.output = nm_strdup(val);
 		}
 	}
 
@@ -2068,7 +2069,7 @@ int delete_check_result_file(char *fname)
 	unlink(fname);
 
 	/* delete the ok-to-go file */
-	asprintf(&temp_buffer, "%s.ok", fname);
+	nm_asprintf(&temp_buffer, "%s.ok", fname);
 	unlink(temp_buffer);
 	my_free(temp_buffer);
 
@@ -2189,9 +2190,7 @@ char *escape_newlines(char *rawbuf)
 		return NULL;
 
 	/* allocate enough memory to escape all chars if necessary */
-	if ((newbuf = malloc((strlen(rawbuf) * 2) + 1)) == NULL)
-		return NULL;
-
+	newbuf = nm_malloc((strlen(rawbuf) * 2) + 1);
 	for (x = 0, y = 0; rawbuf[x] != (char)'\x0'; x++) {
 
 		/* escape backslashes */
@@ -2309,12 +2308,7 @@ int my_fdcopy(char *source, char *dest, int dest_fd)
 	 * cache, so larger isn't necessarily better.
 	 */
 	buf_size = st.st_size > 128 << 10 ? 128 << 10 : st.st_size;
-	buf = malloc(buf_size);
-	if (!buf) {
-		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to malloc(%d) bytes: %s\n", buf_size, strerror(errno));
-		close(source_fd);
-		return ERROR;
-	}
+	buf = nm_malloc(buf_size);
 	/* most of the times, this loop will be gone through once */
 	while (tot_written < st.st_size) {
 		int loop_wr = 0;
@@ -2443,9 +2437,7 @@ int dbuf_strcat(dbuf *db, const char *buf)
 		memory_needed = ((ceil(new_size / db->chunk_size) + 1) * db->chunk_size);
 
 		/* allocate memory to store old and new string */
-		if ((newbuf = (char *)realloc((void *)db->buf, (size_t)memory_needed)) == NULL)
-			return ERROR;
-
+		newbuf = nm_realloc((void *)db->buf, (size_t)memory_needed);
 		/* update buffer pointer */
 		db->buf = newbuf;
 
@@ -2857,23 +2849,23 @@ void free_notification_list(void)
 int reset_variables(void)
 {
 
-	log_file = (char *)strdup(get_default_log_file());
-	temp_file = (char *)strdup(get_default_temp_file());
-	temp_path = (char *)strdup(get_default_temp_path());
-	check_result_path = (char *)strdup(get_default_check_result_path());
-	command_file = (char *)strdup(get_default_command_file());
-	qh_socket_path = (char *)strdup(get_default_query_socket());
+	log_file = nm_strdup(get_default_log_file());
+	temp_file = nm_strdup(get_default_temp_file());
+	temp_path = nm_strdup(get_default_temp_path());
+	check_result_path = nm_strdup(get_default_check_result_path());
+	command_file = nm_strdup(get_default_command_file());
+	qh_socket_path = nm_strdup(get_default_query_socket());
 	if (lock_file) /* this is kept across restarts */
 		free(lock_file);
-	lock_file = (char *)strdup(get_default_lock_file());
-	log_archive_path = (char *)strdup(get_default_log_archive_path());
-	debug_file = (char *)strdup(get_default_debug_file());
+	lock_file = nm_strdup(get_default_lock_file());
+	log_archive_path = nm_strdup(get_default_log_archive_path());
+	debug_file = nm_strdup(get_default_debug_file());
 
-	object_cache_file = (char *)strdup(get_default_object_cache_file());
-	object_precache_file = (char *)strdup(get_default_precached_object_file());
+	object_cache_file = nm_strdup(get_default_object_cache_file());
+	object_precache_file = nm_strdup(get_default_precached_object_file());
 
-	naemon_user = (char *)strdup(DEFAULT_NAEMON_USER);
-	naemon_group = (char *)strdup(DEFAULT_NAEMON_GROUP);
+	naemon_user = nm_strdup(DEFAULT_NAEMON_USER);
+	naemon_group = nm_strdup(DEFAULT_NAEMON_GROUP);
 
 	use_regexp_matches = FALSE;
 	use_true_regexp_matching = FALSE;

--- a/naemon/xpddefault.c
+++ b/naemon/xpddefault.c
@@ -9,6 +9,7 @@
 #include "globals.h"
 #include "logging.h"
 #include "defaults.h"
+#include "nm_alloc.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -58,9 +59,9 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 
 	/* make sure we have some templates defined */
 	if (host_perfdata_file_template == NULL)
-		host_perfdata_file_template = (char *)strdup(DEFAULT_HOST_PERFDATA_FILE_TEMPLATE);
+		host_perfdata_file_template = nm_strdup(DEFAULT_HOST_PERFDATA_FILE_TEMPLATE);
 	if (service_perfdata_file_template == NULL)
-		service_perfdata_file_template = (char *)strdup(DEFAULT_SERVICE_PERFDATA_FILE_TEMPLATE);
+		service_perfdata_file_template = nm_strdup(DEFAULT_SERVICE_PERFDATA_FILE_TEMPLATE);
 
 	/* process special chars in templates */
 	xpddefault_preprocess_file_templates(host_perfdata_file_template);
@@ -72,7 +73,7 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 
 	/* verify that performance data commands are valid */
 	if (host_perfdata_command != NULL) {
-		temp_buffer = (char *)strdup(host_perfdata_command);
+		temp_buffer = nm_strdup(host_perfdata_command);
 		if ((temp_command = find_bang_command(temp_buffer)) == NULL) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Host performance command '%s' was not found - host performance data will not be processed!\n", host_perfdata_command);
 			my_free(host_perfdata_command);
@@ -85,7 +86,7 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 	}
 
 	if (service_perfdata_command != NULL) {
-		temp_buffer = (char *)strdup(service_perfdata_command);
+		temp_buffer = nm_strdup(service_perfdata_command);
 		if ((temp_command = find_bang_command(temp_buffer)) == NULL) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Service performance command '%s' was not found - service performance data will not be processed!\n", service_perfdata_command);
 			my_free(service_perfdata_command);
@@ -98,7 +99,7 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 	}
 
 	if (host_perfdata_file_processing_command != NULL) {
-		temp_buffer = (char *)strdup(host_perfdata_file_processing_command);
+		temp_buffer = nm_strdup(host_perfdata_file_processing_command);
 		if ((temp_command = find_bang_command(temp_buffer)) == NULL) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Host performance file processing command '%s' was not found - host performance data file will not be processed!\n", host_perfdata_file_processing_command);
 			my_free(host_perfdata_file_processing_command);
@@ -112,7 +113,7 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 	}
 
 	if (service_perfdata_file_processing_command != NULL) {
-		temp_buffer = (char *)strdup(service_perfdata_file_processing_command);
+		temp_buffer = nm_strdup(service_perfdata_file_processing_command);
 		if ((temp_command = find_bang_command(temp_buffer)) == NULL) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Service performance file processing command '%s' was not found - service performance data file will not be processed!\n", service_perfdata_file_processing_command);
 			my_free(service_perfdata_file_processing_command);
@@ -133,15 +134,15 @@ int xpddefault_initialize_performance_data(const char *cfgfile)
 	/* save the host perf data file macro */
 	my_free(mac->x[MACRO_HOSTPERFDATAFILE]);
 	if (host_perfdata_file != NULL) {
-		if ((mac->x[MACRO_HOSTPERFDATAFILE] = (char *)strdup(host_perfdata_file)))
-			strip(mac->x[MACRO_HOSTPERFDATAFILE]);
+		mac->x[MACRO_HOSTPERFDATAFILE] = nm_strdup(host_perfdata_file);
+		strip(mac->x[MACRO_HOSTPERFDATAFILE]);
 	}
 
 	/* save the service perf data file macro */
 	my_free(mac->x[MACRO_SERVICEPERFDATAFILE]);
 	if (service_perfdata_file != NULL) {
-		if ((mac->x[MACRO_SERVICEPERFDATAFILE] = (char *)strdup(service_perfdata_file)))
-			strip(mac->x[MACRO_SERVICEPERFDATAFILE]);
+		mac->x[MACRO_SERVICEPERFDATAFILE] = nm_strdup(service_perfdata_file);
+		strip(mac->x[MACRO_SERVICEPERFDATAFILE]);
 	}
 
 	/* free memory */
@@ -446,9 +447,7 @@ int xpddefault_preprocess_file_templates(char *template)
 		return OK;
 
 	/* allocate temporary buffer */
-	tempbuf = (char *)malloc(strlen(template) + 1);
-	if (tempbuf == NULL)
-		return ERROR;
+	tempbuf = nm_malloc(strlen(template) + 1);
 	strcpy(tempbuf, "");
 
 	for (x = 0, y = 0; x < strlen(template); x++, y++) {
@@ -493,7 +492,7 @@ int xpddefault_update_service_performance_data_file(nagios_macros *mac, service 
 		return OK;
 
 	/* get the raw line to write */
-	raw_output = (char *)strdup(service_perfdata_file_template);
+	raw_output = nm_strdup(service_perfdata_file_template);
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Raw service performance data file output: %s\n", raw_output);
 
@@ -534,7 +533,7 @@ int xpddefault_update_host_performance_data_file(nagios_macros *mac, host *hst)
 		return OK;
 
 	/* get the raw output */
-	raw_output = (char *)strdup(host_perfdata_file_template);
+	raw_output = nm_strdup(host_perfdata_file_template);
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Raw host performance file output: %s\n", raw_output);
 

--- a/naemon/xrddefault.c
+++ b/naemon/xrddefault.c
@@ -13,6 +13,7 @@
 #include "globals.h"
 #include "logging.h"
 #include "defaults.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 /******************************************************************/
@@ -26,19 +27,15 @@ int xrddefault_initialize_retention_data(const char *cfgfile)
 
 	/* initialize locations if necessary  */
 	if (retention_file == NULL)
-		retention_file = (char *)strdup(get_default_retention_file());
-
-	/* make sure we have everything */
-	if (retention_file == NULL)
-		return ERROR;
+		retention_file = nm_strdup(get_default_retention_file());
 
 	mac = get_global_macros();
 
 	/* save the retention file macro */
 	my_free(mac->x[MACRO_RETENTIONDATAFILE]);
 	mac->x[MACRO_RETENTIONDATAFILE] = retention_file;
-	if ((mac->x[MACRO_RETENTIONDATAFILE] = (char *)strdup(retention_file)))
-		strip(mac->x[MACRO_RETENTIONDATAFILE]);
+	mac->x[MACRO_RETENTIONDATAFILE] = nm_strdup(retention_file);
+	strip(mac->x[MACRO_RETENTIONDATAFILE]);
 
 	return OK;
 }
@@ -91,7 +88,7 @@ int xrddefault_save_state_information(void)
 	}
 
 	/* open a safe temp file for output */
-	asprintf(&tmp_file, "%sXXXXXX", temp_file);
+	nm_asprintf(&tmp_file, "%sXXXXXX", temp_file);
 	if (tmp_file == NULL)
 		return ERROR;
 	if ((fd = mkstemp(tmp_file)) == -1)
@@ -954,7 +951,7 @@ int xrddefault_read_state_information(void)
 						if (modified_host_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
 
 							/* make sure the check command still exists... */
-							tempval = (char *)strdup(val);
+							tempval = nm_strdup(val);
 							temp_command = find_bang_command(tempval);
 							if (temp_command && tempval) {
 								my_free(global_host_event_handler);
@@ -965,7 +962,7 @@ int xrddefault_read_state_information(void)
 						if (modified_service_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
 
 							/* make sure the check command still exists... */
-							tempval = (char *)strdup(val);
+							tempval = nm_strdup(val);
 							temp_command = find_bang_command(tempval);
 
 							if (temp_command && tempval) {
@@ -1020,13 +1017,13 @@ int xrddefault_read_state_information(void)
 							temp_host->last_hard_state = atoi(val);
 						else if (!strcmp(var, "plugin_output")) {
 							my_free(temp_host->plugin_output);
-							temp_host->plugin_output = (char *)strdup(val);
+							temp_host->plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "long_plugin_output")) {
 							my_free(temp_host->long_plugin_output);
-							temp_host->long_plugin_output = (char *)strdup(val);
+							temp_host->long_plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "performance_data")) {
 							my_free(temp_host->perf_data);
-							temp_host->perf_data = (char *)strdup(val);
+							temp_host->perf_data = nm_strdup(val);
 						} else if (!strcmp(var, "last_check"))
 							temp_host->last_check = strtoul(val, NULL, 10);
 						else if (!strcmp(var, "next_check")) {
@@ -1131,7 +1128,7 @@ int xrddefault_read_state_information(void)
 							if (temp_host->modified_attributes & MODATTR_CHECK_COMMAND) {
 
 								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
+								tempval = nm_strdup(val);
 								temp_command = find_bang_command(tempval);
 								if (temp_command && tempval) {
 									my_free(temp_host->check_command);
@@ -1167,7 +1164,7 @@ int xrddefault_read_state_information(void)
 							if (temp_host->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
 
 								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
+								tempval = nm_strdup(val);
 								temp_command = find_bang_command(tempval);
 								if (temp_command && tempval) {
 									my_free(temp_host->event_handler);
@@ -1198,22 +1195,21 @@ int xrddefault_read_state_information(void)
 							if (temp_host->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
 
 								/* get the variable name */
-								if ((customvarname = (char *)strdup(var + 1))) {
+								customvarname = nm_strdup(var + 1);
 
-									for (temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-										if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-											if ((x = atoi(val)) > 0 && strlen(val) > 3) {
-												my_free(temp_customvariablesmember->variable_value);
-												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-											}
-											break;
+								for (temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+									if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+										if ((x = atoi(val)) > 0 && strlen(val) > 3) {
+											my_free(temp_customvariablesmember->variable_value);
+											temp_customvariablesmember->variable_value = nm_strdup(val + 2);
+											temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
 										}
+										break;
 									}
-
-									/* free memory */
-									my_free(customvarname);
 								}
+
+								/* free memory */
+								my_free(customvarname);
 							}
 
 						}
@@ -1227,7 +1223,7 @@ int xrddefault_read_state_information(void)
 
 				if (temp_service == NULL) {
 					if (!strcmp(var, "host_name")) {
-						host_name = (char *)strdup(val);
+						host_name = nm_strdup(val);
 						break;
 					} else if (!strcmp(var, "service_description")) {
 						temp_service = find_service(host_name, val);
@@ -1303,13 +1299,13 @@ int xrddefault_read_state_information(void)
 							temp_service->last_time_critical = strtoul(val, NULL, 10);
 						else if (!strcmp(var, "plugin_output")) {
 							my_free(temp_service->plugin_output);
-							temp_service->plugin_output = (char *)strdup(val);
+							temp_service->plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "long_plugin_output")) {
 							my_free(temp_service->long_plugin_output);
-							temp_service->long_plugin_output = (char *)strdup(val);
+							temp_service->long_plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "performance_data")) {
 							my_free(temp_service->perf_data);
-							temp_service->perf_data = (char *)strdup(val);
+							temp_service->perf_data = nm_strdup(val);
 						} else if (!strcmp(var, "last_check"))
 							temp_service->last_check = strtoul(val, NULL, 10);
 						else if (!strcmp(var, "next_check")) {
@@ -1394,7 +1390,7 @@ int xrddefault_read_state_information(void)
 							if (temp_service->modified_attributes & MODATTR_CHECK_COMMAND) {
 
 								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
+								tempval = nm_strdup(val);
 								temp_command = find_bang_command(tempval);
 								if (temp_command && tempval) {
 									my_free(temp_service->check_command);
@@ -1431,7 +1427,7 @@ int xrddefault_read_state_information(void)
 							if (temp_service->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
 
 								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
+								tempval = nm_strdup(val);
 								temp_command = find_bang_command(temp_ptr);
 								if (temp_command && tempval) {
 									my_free(temp_service->event_handler);
@@ -1463,22 +1459,20 @@ int xrddefault_read_state_information(void)
 							if (temp_service->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
 
 								/* get the variable name */
-								if ((customvarname = (char *)strdup(var + 1))) {
-
-									for (temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-										if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-											if ((x = atoi(val)) > 0 && strlen(val) > 3) {
-												my_free(temp_customvariablesmember->variable_value);
-												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-											}
-											break;
+								customvarname = nm_strdup(var + 1);
+								for (temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+									if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+										if ((x = atoi(val)) > 0 && strlen(val) > 3) {
+											my_free(temp_customvariablesmember->variable_value);
+											temp_customvariablesmember->variable_value = nm_strdup(val + 2);
+											temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
 										}
+										break;
 									}
-
-									/* free memory */
-									my_free(customvarname);
 								}
+
+								/* free memory */
+								my_free(customvarname);
 							}
 						}
 					}
@@ -1489,7 +1483,7 @@ int xrddefault_read_state_information(void)
 			case XRDDEFAULT_CONTACTSTATUS_DATA:
 				if (temp_contact == NULL) {
 					if (!strcmp(var, "contact_name")) {
-						contact_name = (char *)strdup(val);
+						contact_name = nm_strdup(val);
 						temp_contact = find_contact(contact_name);
 					}
 				} else {
@@ -1574,22 +1568,20 @@ int xrddefault_read_state_information(void)
 							if (temp_contact->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
 
 								/* get the variable name */
-								if ((customvarname = (char *)strdup(var + 1))) {
-
-									for (temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-										if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-											if ((x = atoi(val)) > 0 && strlen(val) > 3) {
-												my_free(temp_customvariablesmember->variable_value);
-												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-											}
-											break;
+								customvarname = nm_strdup(var + 1);
+								for (temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+									if (!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+										if ((x = atoi(val)) > 0 && strlen(val) > 3) {
+											my_free(temp_customvariablesmember->variable_value);
+											temp_customvariablesmember->variable_value = nm_strdup(val + 2);
+											temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
 										}
+										break;
 									}
-
-									/* free memory */
-									my_free(customvarname);
 								}
+
+								/* free memory */
+								my_free(customvarname);
 							}
 						}
 					}
@@ -1599,9 +1591,9 @@ int xrddefault_read_state_information(void)
 			case XRDDEFAULT_HOSTCOMMENT_DATA:
 			case XRDDEFAULT_SERVICECOMMENT_DATA:
 				if (!strcmp(var, "host_name"))
-					host_name = (char *)strdup(val);
+					host_name = nm_strdup(val);
 				else if (!strcmp(var, "service_description"))
-					service_description = (char *)strdup(val);
+					service_description = nm_strdup(val);
 				else if (!strcmp(var, "entry_type"))
 					entry_type = atoi(val);
 				else if (!strcmp(var, "comment_id"))
@@ -1617,17 +1609,17 @@ int xrddefault_read_state_information(void)
 				else if (!strcmp(var, "expire_time"))
 					expire_time = strtoul(val, NULL, 10);
 				else if (!strcmp(var, "author"))
-					author = (char *)strdup(val);
+					author = nm_strdup(val);
 				else if (!strcmp(var, "comment_data"))
-					comment_data = (char *)strdup(val);
+					comment_data = nm_strdup(val);
 				break;
 
 			case XRDDEFAULT_HOSTDOWNTIME_DATA:
 			case XRDDEFAULT_SERVICEDOWNTIME_DATA:
 				if (!strcmp(var, "host_name"))
-					host_name = (char *)strdup(val);
+					host_name = nm_strdup(val);
 				else if (!strcmp(var, "service_description"))
-					service_description = (char *)strdup(val);
+					service_description = nm_strdup(val);
 				else if (!strcmp(var, "downtime_id"))
 					downtime_id = strtoul(val, NULL, 10);
 				else if (!strcmp(var, "comment_id"))
@@ -1651,9 +1643,9 @@ int xrddefault_read_state_information(void)
 				else if (!strcmp(var, "duration"))
 					duration = strtoul(val, NULL, 10);
 				else if (!strcmp(var, "author"))
-					author = (char *)strdup(val);
+					author = nm_strdup(val);
 				else if (!strcmp(var, "comment"))
-					comment_data = (char *)strdup(val);
+					comment_data = nm_strdup(val);
 				break;
 
 			default:

--- a/naemon/xsddefault.c
+++ b/naemon/xsddefault.c
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "logging.h"
 #include "globals.h"
+#include "nm_alloc.h"
 #include <string.h>
 
 time_t program_start;
@@ -41,7 +42,7 @@ int xsddefault_initialize_status_data(const char *cfgfile)
 
 	/* initialize locations if necessary */
 	if (!status_file)
-		status_file = (char *)strdup(get_default_status_file());
+		status_file = nm_strdup(get_default_status_file());
 
 	/* make sure we have what we need */
 	if (status_file == NULL)
@@ -50,8 +51,8 @@ int xsddefault_initialize_status_data(const char *cfgfile)
 	mac = get_global_macros();
 	/* save the status file macro */
 	my_free(mac->x[MACRO_STATUSDATAFILE]);
-	if ((mac->x[MACRO_STATUSDATAFILE] = (char *)strdup(status_file)))
-		strip(mac->x[MACRO_STATUSDATAFILE]);
+	mac->x[MACRO_STATUSDATAFILE] = nm_strdup(status_file);
+	strip(mac->x[MACRO_STATUSDATAFILE]);
 
 	/* delete the old status log (it might not exist) */
 	if (status_file)
@@ -103,7 +104,7 @@ int xsddefault_save_status_data(void)
 	if (!status_file || !strcmp(status_file, "/dev/null"))
 		return OK;
 
-	asprintf(&tmp_log, "%sXXXXXX", temp_file);
+	nm_asprintf(&tmp_log, "%sXXXXXX", temp_file);
 	if (tmp_log == NULL)
 		return ERROR;
 

--- a/t-tap/Makefile.am
+++ b/t-tap/Makefile.am
@@ -8,7 +8,7 @@ BASE_DEPS = broker.o checks.o commands.o comments.o \
 	macros.o nebmods.o notifications.o objects.o perfdata.o \
 	query-handler.o sehandlers.o shared.o sretention.o statusdata.o \
 	workers.o xodtemplate.o xpddefault.o xrddefault.o \
-	xsddefault.o
+	xsddefault.o nm_alloc.o
 TIMEPERIODS_DEPS = $(BASE_DEPS)
 MACROS_DEPS = $(BASE_DEPS) utils.o
 CHECKS_DEPS = $(BASE_DEPS) utils.o

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ AM_CFLAGS += @CHECK_CFLAGS@
 TESTS = test-checks test-log test-config
 TEST_CHECKS_DEPS = nebmods.o commands.o broker.o query-handler.o utils.o events.o notifications.o \
 			  flapping.o sehandlers.o logging.o workers.o shared.o comments.o downtime.o sretention.o objects.o \
-			  macros.o statusdata.o xrddefault.o xsddefault.o xpddefault.o perfdata.o xodtemplate.o
+			  macros.o statusdata.o xrddefault.o xsddefault.o xpddefault.o perfdata.o xodtemplate.o nm_alloc.o
 test_checks_SOURCES	= test-checks.c $(top_srcdir)/naemon/checks.h $(top_srcdir)/naemon/checks.c $(top_srcdir)/naemon/defaults.c
 test_checks_LDADD =  $(TEST_CHECKS_DEPS:%=$(top_builddir)/naemon/naemon-%) $(LDADD)
 TEST_LOG_DEPS = $(TEST_CHECKS_DEPS) checks.o


### PR DESCRIPTION
This patch adds an aborting implementation of the following functions:

malloc
calloc
realloc
strdup
strndup
asprintf

and changes all calls to them to their aborting counterpart (prefixed by
nm_, e.g nm_malloc).

Why? Because we really, really, really don't handle
memory allocation failure gracefully at all, ever. Maybe we want to
pretend that we do by doing:

if ( ptr = malloc(sizeof(foo)) == NULL)
    return NULL;

But how is anyone supposed to know that we just ran out of memory from
that? Not that it matters since naemon is not designed to degrade
gracefully _anyway_. What would we do if we somehow successfully
identified that we have no memory? It's not like we can do anything
worthwhile anyways, say, like running checks or sending notifications or
...

This has the positive side effect of getting rid of a lot of pointless
complexity and silencing a whole bunch of warnings about "unused return
values" and the like. See #69.

Anyhow, the aforementioned checks for MA failure were not really that
common anyway, meaning that an actual scenario where we had really run
OOM would be more likely to result in a segfault than anything else.

In all, I could find _one_ place where we actually did something
productive in case memory was not returned, namely when we were about to
start a new worker. And what did we do then? Log it. And abort.

In conclusion, we no longer hide/escalate errors for "someone else" to
deal with for any value of "someone else" that equals "noone".

goto endrant;

This partially fixes #69.

Signed-off-by: Anton Lofgren alofgren@op5.com
