### PR TITLE
Make sure we've succesfully read()

### DIFF
--- a/naemon/naemon.c
+++ b/naemon/naemon.c
@@ -145,9 +145,14 @@ static int nagios_core_worker(const char *path)
 		return 1;
 	}
 	if (memcmp(response, "OK", 3)) {
-		read(sd, response + 3, sizeof(response) - 4);
-		response[sizeof(response) - 2] = 0;
-		printf("Failed to register with wproc manager: %s\n", response);
+		printf("Failed to register with wproc manager: ");
+		if (read(sd, response + 3, sizeof(response) - 4) > 0) {
+			response[sizeof(response) - 2] = 0;
+			printf("%s\n", response);
+		}
+		else {
+			printf("[failed to read response (%s)]\n", strerror(errno));
+		}
 		return 1;
 	}
 


### PR DESCRIPTION
If we've failed to register with the wproc manager, and also fail to
read the entire response, it makes more sense to output the value of
errno, since that might better indicate what's actually going on.

Besides, it's good practice to check your return values.

Signed-off-by: Anton Lofgren alofgren@op5.com
