### PR TITLE
utils: Bail if we fail to truncate lockfile

### DIFF
--- a/naemon/utils.c
+++ b/naemon/utils.c
@@ -1673,7 +1673,11 @@ int daemon_init(void)
 
 	/* write PID to lockfile... */
 	lseek(lockfile, 0, SEEK_SET);
-	ftruncate(lockfile, 0);
+	if (ftruncate(lockfile, 0) != 0) {
+		logit(NSLOG_RUNTIME_ERROR, TRUE, "Cannot truncate lockfile '%s': %s. Bailing out...", lock_file, strerror(errno));
+		cleanup();
+		exit(ERROR);
+	}
 	sprintf(buf, "%d\n", (int)getpid());
 	write(lockfile, buf, strlen(buf));
 


### PR DESCRIPTION
If we can't truncate it, we're most likely not going to be able to write
our PID to it. Bail early, and let the user know what's going on.

Signed-off-by: Anton Lofgren alofgren@op5.com
