### PR TITLE
utils: Add uninterrupted_write()

### DIFF
--- a/naemon/lib/worker.c
+++ b/naemon/lib/worker.c
@@ -640,7 +640,7 @@ static int receive_command(int sd, int events, void *arg)
 #if 0
 	/* debug-volley */
 	buf = iocache_use_size(ioc, ioc_ret);
-	write(master_sd, buf, ioc_ret);
+	uninterrupted_write(master_sd, buf, ioc_ret);
 	return 0;
 #endif
 	/*

--- a/naemon/query-handler.c
+++ b/naemon/query-handler.c
@@ -36,8 +36,7 @@ static int qh_echo(int sd, char *buf, unsigned int len)
 		                 "Query handler that simply echoes back what you send it.");
 		return 0;
 	}
-	(void)write(sd, buf, len);
-	return 0;
+	return uninterrupted_write(sd, buf, len);
 }
 
 static struct query_handler *qh_find_handler(const char *name)

--- a/naemon/utils.c
+++ b/naemon/utils.c
@@ -413,14 +413,14 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 			buffer[sizeof(buffer) - 1] = '\x0';
 
 			/* write the error back to the parent process */
-			write(fd[1], buffer, strlen(buffer) + 1);
+			uninterrupted_write(fd[1], buffer, strlen(buffer) + 1);
 
 			result = STATE_CRITICAL;
 		} else {
 
 			/* write all the lines of output back to the parent process */
 			while (fgets(buffer, sizeof(buffer) - 1, fp))
-				write(fd[1], buffer, strlen(buffer));
+				uninterrupted_write(fd[1], buffer, strlen(buffer));
 
 			/* close the command and get termination status */
 			status = pclose(fp);
@@ -1435,6 +1435,28 @@ void my_system_sighandler(int sig)
 	_exit(STATE_CRITICAL);
 }
 
+/**
+ * Write all of nbyte bytes of buf to fd, and don't let EINTR/EAGAIN stop you.
+ * Returns 0 on success. On error, returns -1 and errno is set to indicate the
+ * error
+ */
+int uninterrupted_write(int fd, const void *buf, size_t nbyte)
+{
+	size_t c = 0;
+	int ret = 0;
+	while ( c < nbyte ) {
+		ret = write(fd, (char *) buf + c, nbyte - c);
+		if (ret < 0) {
+			if (errno == EINTR || errno == EAGAIN)
+				continue;
+
+			logit(NSLOG_RUNTIME_ERROR, TRUE, "%s", strerror(errno));
+			return -1;
+		}
+		c += (size_t)ret;
+	}
+	return 0;
+}
 
 /**
  * Handle the SIGXFSZ signal. A SIGXFSZ signal is received when a file exceeds
@@ -1675,7 +1697,7 @@ int daemon_init(void)
 	lseek(lockfile, 0, SEEK_SET);
 	ftruncate(lockfile, 0);
 	sprintf(buf, "%d\n", (int)getpid());
-	write(lockfile, buf, strlen(buf));
+	uninterrupted_write(lockfile, buf, strlen(buf));
 
 	/* make sure lock file stays open while program is executing... */
 	val = fcntl(lockfile, F_GETFD, 0);

--- a/naemon/utils.h
+++ b/naemon/utils.h
@@ -48,6 +48,13 @@ int my_fdcopy(char *, char *, int);                     /* copies a named source
 /* thread-safe version of get_raw_command_line_r() */
 int get_raw_command_line_r(nagios_macros *mac, command *, char *, char **, int);
 
+/**
+ * Write all of nbyte bytes of buf to fd, and don't let EINTR/EAGAIN stop you.
+ * Returns 0 on success. On error, returns -1 and errno is set to indicate the
+ * error
+ */
+int uninterrupted_write(int fd, const void *buf, size_t nbyte);
+
 /*
  * given a raw command line, determine the actual command to run
  * Manipulates global_macros.argv and is thus not threadsafe


### PR DESCRIPTION
This function lets us transparently handle EAGAIN/EINTR during writes
by retrying, which we want to do any time they pop up. This also has the
added benefit of silencing warnings about unchecked returns for write
calls, in addition to actually checking the return and logging a message
if something goes horribly wrong, which should make debugging easier in
the future.

Signed-off-by: Anton Lofgren alofgren@op5.com
