### PR TITLE
commands: Remove useless assignment

### DIFF
--- a/naemon/commands.c
+++ b/naemon/commands.c
@@ -680,10 +680,10 @@ static const char * arg_t2str(arg_t type)
 }
 static int parse_arguments(const char *s, struct external_command_argument **args, int argc)
 {
-	char *scopy, *next, *temp;
+	char *scopy, *next, *temp = NULL;
 	int i = 0, error = 0, ret = CMD_ERROR_OK;
 
-	temp = scopy = nm_strdup(s);
+	scopy = nm_strdup(s);
 	/* stash ptr start for free()ing, since *s is const and we copy it */
 	for (temp = scopy; temp && ret == CMD_ERROR_OK; i++, temp = next ? next + 1 : NULL) {
 		next = strchr(temp, ';');


### PR DESCRIPTION
`temp` is assigned the value of `scopy` as the loop is initialised. No
need in doing so before, since that just confuses things.

Signed-off-by: Anton Lofgren alofgren@op5.com
