### PR TITLE
shared: Fix null pointer deref in my_strtok

### DIFF
--- a/naemon/shared.c
+++ b/naemon/shared.c
@@ -87,7 +87,11 @@ char *my_strtok(char *buffer, const char *tokens)
 	static char *my_strtok_buffer = NULL;
 	static char *original_my_strtok_buffer = NULL;
 
-	if (buffer != NULL) {
+	if (buffer == NULL) {
+		if (my_strtok_buffer == NULL)
+			return NULL; /*nothing supplied, nothing stored*/
+	}
+	else {
 		my_free(original_my_strtok_buffer);
 		my_strtok_buffer = nm_strdup(buffer);
 		original_my_strtok_buffer = my_strtok_buffer;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,12 +3,17 @@ if HAVE_CHECK
 LDADD = @CHECK_LIBS@ $(top_builddir)/naemon/lib/libnaemon.la -lm -ldl
 AM_CPPFLAGS += -I$(top_srcdir) '-DSYSCONFDIR="$(abs_srcdir)/configs/"'
 AM_CFLAGS += @CHECK_CFLAGS@
-TESTS = test-checks test-log test-config
+TESTS = test-checks test-utils test-log test-config
 TEST_CHECKS_DEPS = nebmods.o commands.o broker.o query-handler.o utils.o events.o notifications.o \
 			  flapping.o sehandlers.o logging.o workers.o shared.o comments.o downtime.o sretention.o objects.o \
 			  macros.o statusdata.o xrddefault.o xsddefault.o xpddefault.o perfdata.o xodtemplate.o nm_alloc.o
 test_checks_SOURCES	= test-checks.c $(top_srcdir)/naemon/checks.h $(top_srcdir)/naemon/checks.c $(top_srcdir)/naemon/defaults.c
 test_checks_LDADD =  $(TEST_CHECKS_DEPS:%=$(top_builddir)/naemon/naemon-%) $(LDADD)
+
+TEST_UTILS_DEPS = $(TEST_CHECKS_DEPS) checks.o
+test_utils_SOURCES	= test-utils.c $(top_srcdir)/naemon/defaults.c
+test_utils_LDADD =  $(TEST_UTILS_DEPS:%=$(top_builddir)/naemon/naemon-%) $(LDADD)
+
 TEST_LOG_DEPS = $(TEST_CHECKS_DEPS) checks.o
 test_log_SOURCES	= test-log.c $(top_srcdir)/naemon/defaults.c
 test_log_LDADD = $(TEST_LOG_DEPS:%=$(top_builddir)/naemon/naemon-%) $(LDADD)

--- a/tests/test-utils.c
+++ b/tests/test-utils.c
@@ -1,0 +1,32 @@
+#include <check.h>
+#include "naemon/utils.h"
+
+
+START_TEST(my_strtok_null_buffer)
+{
+	char *result = NULL;
+	result = my_strtok(NULL, "X");
+	ck_assert(NULL == result);
+}
+END_TEST
+
+Suite*
+utils_suite(void)
+{
+	Suite *s = suite_create("Utilities");
+	TCase *tc_my_strtok = tcase_create("my_strtok");
+	tcase_add_test(tc_my_strtok, my_strtok_null_buffer);
+	suite_add_tcase(s, tc_my_strtok);
+	return s;
+}
+
+int main(void)
+{
+	int number_failed = 0;
+	Suite *s = utils_suite();
+	SRunner *sr = srunner_create(s);
+	srunner_run_all(sr, CK_NORMAL);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
If my_strtok was supplied with a NULL buffer on the first call,
it would (needlessly) trigger a null pointer dereference. This patch
adds a check for that case and a test case that triggers the error
without the patch applied.

Signed-off-by: Anton Lofgren alofgren@op5.com
