### PR TITLE
[#83] Inherit service check period from host

### DIFF
--- a/naemon/xodtemplate.c
+++ b/naemon/xodtemplate.c
@@ -3496,6 +3496,9 @@ static int xodtemplate_inherit_object_properties(void)
 		/* services inherit notification period from host if not already specified */
 		xod_inherit_str(temp_service, temp_host, notification_period);
 
+		/* services inherit check period from host if not already specified */
+		xod_inherit_str(temp_service, temp_host, check_period);
+
 		/* if notification options are missing, assume all */
 		if (temp_service->have_notification_options == FALSE) {
 			temp_service->notification_options = OPT_ALL;


### PR DESCRIPTION
This is a pull request for issue #83.

If a service check period is not explicitly specified, it gets inherited
from the corresponding host definition. This allows simpler
configuration for hosts which share services but have different check
periods.
