### PR TITLE
Service heredity of contacts and contact groups

### DIFF
--- a/naemon/xodtemplate.c
+++ b/naemon/xodtemplate.c
@@ -3482,11 +3482,18 @@ static int xodtemplate_inherit_object_properties(void)
 			continue;
 
 		/*
+		 * if the service has no contact groups specified, it will inherit
+		 * them from the host
+		 */
+		if(temp_service->have_contact_groups == FALSE) {
+			xod_inherit_str(temp_service, temp_host, contact_groups);
+		}
+		
+		/*
 		 * if the service has no contacts specified, it will inherit
 		 * them from the host
 		 */
-		if (temp_service->have_contact_groups == FALSE && temp_service->have_contacts == FALSE) {
-			xod_inherit_str(temp_service, temp_host, contact_groups);
+		if(temp_service->have_contacts == FALSE && temp_host->have_contacts == TRUE) {
 			xod_inherit_str(temp_service, temp_host, contacts);
 		}
 


### PR DESCRIPTION
The problem is, that due to the following if condition, a service only
can inherit contact groups AND contacts:
if(temp_service->have_contact_groups == FALSE &&
temp_service->have_contacts == FALSE) {

But if you define a host with a contact and a contact group, and a
service with only a contact for example, only your service contact will
get an notification, but not the contact group that normally should be
inherited from the host.
If you want to stop the heredity you can add a contact or contact group
with notification interval none. I guess this is a better solution with
more flexibility for the admins
