### PR TITLE
Minor spelling error, hostgrop -> hostgroup

### DIFF
--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -6270,7 +6270,7 @@ static int xodtemplate_register_hostgroup_members(void *hgrp, void *cookie)
 	for (list = this_hostgroup->member_list; list; list = list->next) {
 		xodtemplate_host *h = (xodtemplate_host *)list->object_ptr;
 		if (!add_host_to_hostgroup(hg, h->host_name)) {
-			nm_log(NSLOG_CONFIG_ERROR, "Error: Bad member of hostgrop '%s' (config file '%s', starting on line %d)\n", hg->group_name, xodtemplate_config_file_name(this_hostgroup->_config_file), this_hostgroup->_start_line);
+			nm_log(NSLOG_CONFIG_ERROR, "Error: Bad member of hostgroup '%s' (config file '%s', starting on line %d)\n", hg->group_name, xodtemplate_config_file_name(this_hostgroup->_config_file), this_hostgroup->_start_line);
 			return -1;
 		}
 		(*counter)++;


### PR DESCRIPTION
Noticed the error while using naemon; not a complete review of comments/code