### PR TITLE
Updated daemon-init.in to protect reloads from killing the daemon

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -168,6 +168,8 @@ restart() {
 }
 
 reload() {
+    check_config
+    checkconfig="true"
     echo -n "Reloading $prog: "
     pkill -HUP -u ${user} -f ${exec}
     retval=$?


### PR DESCRIPTION
On CentOS 6, doing service reloads when having broken object configuration will kill the main naemon process.  Added check_config to the reload command will prevent the reload from happening and show that the current configuration is invalid.