### PR TITLE
Fix segfault issue on newline output from plugin

### DIFF
--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -2850,7 +2850,7 @@ struct check_output *parse_output(const char *buf, struct check_output *check_ou
 
 	dbuf_init(&perf_data_dbuf, 1024);
 	tmp = strtok_r(tmpbuf, "\n", &saveptr);
-	p = strpbrk((const char *) tmp, "|");
+	p = tmp ? strpbrk((const char *) tmp, "|") : NULL;
 	if (p == NULL) {
 		/* No perfdata in first line of output. */
 			check_output->short_output = tmp ? nm_strdup(tmp) : nm_strdup("");


### PR DESCRIPTION
Prevent Naemon from segfaulting when a plugin's
output is one or more newlines only.