### PR TITLE
shadownaemon: faster return to short poll interval

### DIFF
--- a/src/shadownaemon/shadownaemon.c
+++ b/src/shadownaemon/shadownaemon.c
@@ -1722,7 +1722,7 @@ int run_refresh_loop() {
             /* use fast interval otherwise */
             sleep_remaining = short_shadow_update_interval - (duration*1000000);
         }
-        if(sigshutdown == TRUE || sigrestart == TRUE)
+        if(sigshutdown == TRUE || sigrestart == TRUE || sleep_remaining > short_shadow_update_interval)
             sleep_remaining = 0;
         if(sleep_remaining > 0)
             usleep(sleep_remaining);


### PR DESCRIPTION
If there have been requests while using the long poll
interval, shadownaemon no longer sleeps for the remainder
of the long interval before returning to the main refresh loop.