### PR TITLE
Resolved ignore check_interval issue #117

### DIFF
--- a/src/naemon/checks.h
+++ b/src/naemon/checks.h
@@ -21,7 +21,7 @@
 #define retry_check_window(o) ((time_t)(o->retry_interval * interval_length))
 #define next_check_time(o) _next_check_time(o->last_check, check_window(o))
 #define check_window(o) \
-	((!o->current_state && o->state_type == SOFT_STATE) ? \
+	((o->current_state != STATE_OK && o->state_type == SOFT_STATE) ? \
 		retry_check_window(o) : \
 		normal_check_window(o))
 


### PR DESCRIPTION
Fix the check_window condition in checks.h so naemon will use the retry_interval again instead of check_interval