### PR TITLE
make it possible to build official packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ naemon.log
 *.8
 *.log
 *.trs
+.naemon.official

--- a/version.sh
+++ b/version.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
-if test -e .git; then
-	git describe --always --tags --dirty | \
-		sed -e 's/^v//' -e 's/-[0-9]*-g/-g/' | tr -d '\n'
-	exit 0
-fi
 
 VERSION=1.0.3
-echo -n "${VERSION}-source"
+if test -e .git; then
+    VERSION=$(git describe --always --tags --dirty | \
+        sed -e 's/^v//' -e 's/-[0-9]*-g/-g/' | tr -d '\n')
+fi
+
+if [ -e .naemon.official ]; then
+  echo -n "${VERSION}-pkg"
+else
+  echo -n "${VERSION}-source"
+fi
+
+exit 0


### PR DESCRIPTION
Right now, the -source appendix is hard coded in the version script,
so add a way to flag official builds by an empty file.

Signed-off-by: Sven Nierlein <Sven.Nierlein@consol.de>