### PR TITLE
lower loglevel for exiting worker

### DIFF
--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -280,7 +280,11 @@ static int command_file_worker(int sd)
 
 		/* if our master has gone away, we need to die */
 		if (kill(nagios_pid, 0) < 0 && errno == ESRCH) {
-			nm_log(NSLOG_RUNTIME_ERROR, "Command file worker: Naemon main process is dead (%m)");
+			/* leads to abandoned worker writing into a already rotated logfile, which
+			 * a bad thing because rotated logfiles then have overlapping timestamps
+			 * which breaks livestatus. So make this a debug log entry only.
+			 */
+			log_debug_info(DEBUGL_IPC, 1, "Command file worker: Naemon main process is dead (%m)");
 			return EXIT_SUCCESS;
 		}
 


### PR DESCRIPTION
If a worker exits because the main naemon process has exited it writes
one last log entry. This entry is likely to end up in an already rotated
old logfile which breaks livestatus.
It then exits with EXIT_SUCCESS, so its not really an error anyway and
therefor we can just lower the loglevel.

Signed-off-by: Sven Nierlein <sven@nierlein.de>