### PR TITLE
systemd: do not use precached objects

### DIFF
--- a/daemon-systemd.in
+++ b/daemon-systemd.in
@@ -10,8 +10,8 @@ PIDFile=@lockfile@
 PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/mkdir /var/run/naemon
 ExecStartPre=/usr/bin/chown -R naemon:naemon /var/run/naemon/
-ExecStartPre=su naemon --login --shell=/bin/sh --command="@bindir@/naemon --verify-config --precache-objects @pkgconfdir@/naemon.cfg"
-ExecStart=@bindir@/naemon --use-precache-objects --daemon @pkgconfdir@/naemon.cfg
+ExecStartPre=su naemon --login --shell=/bin/sh --command="@bindir@/naemon --verify-config @pkgconfdir@/naemon.cfg"
+ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=naemon
 Group=naemon


### PR DESCRIPTION
Precached objects file was created before but never used. So there is no need to create it.