### PR TITLE
remove NICELEVEL from systemd service

### DIFF
--- a/daemon-systemd.in
+++ b/daemon-systemd.in
@@ -15,7 +15,6 @@ ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=naemon
 Group=naemon
-#Nice=$NICELEVEL
 StandardOutput=journal
 StandardError=inherit
 

--- a/daemon-systemd.in
+++ b/daemon-systemd.in
@@ -15,7 +15,7 @@ ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=naemon
 Group=naemon
-Nice=$NICELEVEL
+#Nice=$NICELEVEL
 StandardOutput=journal
 StandardError=inherit
 


### PR DESCRIPTION
NICELEVEL is not set by default, so systemd constantly complains about the value not beeing set.