### PR TITLE
systemd requires absolute path in execstart

### DIFF
--- a/daemon-systemd.in
+++ b/daemon-systemd.in
@@ -10,7 +10,7 @@ PIDFile=@lockfile@
 PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/mkdir /var/run/naemon
 ExecStartPre=/usr/bin/chown -R naemon:naemon /var/run/naemon/
-ExecStartPre=su naemon --login --shell=/bin/sh --command="@bindir@/naemon --verify-config @pkgconfdir@/naemon.cfg"
+ExecStartPre=/bin/su naemon --login --shell=/bin/sh --command="@bindir@/naemon --verify-config @pkgconfdir@/naemon.cfg"
 ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=naemon


### PR DESCRIPTION
from man systemd.service "For each of the specified commands, the first argument must be an absolute path to an executable."