### PR TITLE
Minimize the amount of verify-config

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -62,15 +62,6 @@ status() {
 start() {
     test -x $exec || exit 5
     test -f $config || exit 6
-    if [ "$checkconfig" = "false" ]; then
-        $0 configtest > /dev/null
-        retval=$?
-        if [ "$retval" != "0" ]; then
-            echo "Cowardly refusing to start, failed to verify config"
-            echo "Run '$0 configtest' for more info"
-            exit $retval
-        fi
-    fi
     echo -n "Starting $prog: "
     # Create PID folder if it does not exist
     if [ ! -d $pidfolder ]; then
@@ -115,14 +106,6 @@ stop() {
 
 
 restart() {
-    $0 configtest > /dev/null
-    retval=$?
-    if [ "$retval" != "0" ]; then
-        echo "Cowardly refusing to restart, failed to verify config"
-        echo "Run '$0 configtest' for more info"
-        exit $retval
-    fi
-    checkconfig="true"
     stop
     start
     return $?

--- a/daemon-systemd.in
+++ b/daemon-systemd.in
@@ -10,7 +10,6 @@ PIDFile=@lockfile@
 PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/mkdir /var/run/naemon
 ExecStartPre=/usr/bin/chown -R naemon:naemon /var/run/naemon/
-ExecStartPre=/bin/su naemon --login --shell=/bin/sh --command="@bindir@/naemon --verify-config @pkgconfdir@/naemon.cfg"
 ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=naemon

--- a/op5build/naemon.service.in
+++ b/op5build/naemon.service.in
@@ -10,7 +10,6 @@ PermissionsStartOnly=true
 ExecStartPre=/usr/bin/sh /etc/sysconfig/naemon
 ExecStartPre=-/usr/bin/mkdir --parents @TMPDIR@
 ExecStartPre=/usr/bin/chown --recursive monitor:apache @TMPDIR@
-ExecStartPre=su monitor --login --shell=/bin/sh --command="@bindir@/naemon --verify-config --precache-objects @pkgconfdir@/naemon.cfg"
 ExecStart=@bindir@/naemon --daemon @pkgconfdir@/naemon.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 User=monitor


### PR DESCRIPTION
In a large setup where it can take more than 30 seconds to verify a config.

I propose a implementation similar to other systems, like Apache httpd.
* If you change your config and restart Apache httpd, the server won't start
and you have a broken config. (Expected)
* If you run a verify on the config, it will verify without interrupt with
your current running instance.

But doing this we can speed up the actual start/stop/restart of the naemon
process.

Signed-off-by: Mattias Ryrlén <mattiasr@op5.com>