### PR TITLE
fix segfault in notifications when there is no eventbroker

### DIFF
--- a/src/naemon/nebmods.c
+++ b/src/naemon/nebmods.c
@@ -369,6 +369,8 @@ static neb_cb_resultset *neb_cb_resultset_create(void)
 
 void neb_cb_resultset_destroy(neb_cb_resultset *cbrs)
 {
+	if(cbrs == NULL)
+		return;
 	g_ptr_array_free(cbrs->cb_results, TRUE);
 	nm_free(cbrs);
 }


### PR DESCRIPTION
nebcallback resultset may be null if eventbroker options prevent
notifications from beeing brokered. Do not segfault in those
cases.

Signed-off-by: Sven Nierlein <sven@nierlein.de>