### PR TITLE
Feature/mon 10198 fail naemon start when daemonizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile
 *.gcov
 *.a
 *.so
+*.pyc
 gmon.out
 core.[1-9]*
 /Documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,22 @@ language: c
 compiler:
   - gcc
 # Change this to your needs
-script:
-  - ./autogen.sh
-  - make
-after_success:
-  - make check || exit 1
-  - make distcheck || exit 1
-before_install:
+install:
   - sudo apt-get install autoconf
   - sudo apt-get install build-essential
   - sudo apt-get install gperf
   - sudo apt-get install check
   - sudo apt-get install help2man
+  - sudo apt-get install python-pip
+  - sudo pip install behave flake8
+before_script:
+  - ./autogen.sh
+  - make
+script:
+  - make check
+  - make distcheck
+  - flake8
+  - behave
 notifications:
   irc:
     channels:

--- a/behave.ini
+++ b/behave.ini
@@ -1,0 +1,3 @@
+[behave.userdata]
+shared_libs_path = .libs/
+naemon_exec_path = src/naemon/.libs/naemon

--- a/daemon-init.in
+++ b/daemon-init.in
@@ -62,15 +62,6 @@ status() {
 start() {
     test -x $exec || exit 5
     test -f $config || exit 6
-    if [ "$checkconfig" = "false" ]; then
-        $0 configtest > /dev/null
-        retval=$?
-        if [ "$retval" != "0" ]; then
-            echo "Cowardly refusing to start, failed to verify config"
-            echo "Run '$0 configtest' for more info"
-            exit $retval
-        fi
-    fi
     echo -n "Starting $prog: "
     # Create PID folder if it does not exist
     if [ ! -d $pidfolder ]; then
@@ -115,14 +106,6 @@ stop() {
 
 
 restart() {
-    $0 configtest > /dev/null
-    retval=$?
-    if [ "$retval" != "0" ]; then
-        echo "Cowardly refusing to restart, failed to verify config"
-        echo "Run '$0 configtest' for more info"
-        exit $retval
-    fi
-    checkconfig="true"
     stop
     start
     return $?

--- a/features/daemonize.feature
+++ b/features/daemonize.feature
@@ -1,0 +1,26 @@
+Feature: Daemonization
+    Naemon should successfully daemonize if and only if there is a valid
+    configuration available.
+
+    Scenario: Naemon fails to daemonize when an invalid system config is
+        provided
+        Given I have an invalid naemon system configuration
+        And config verification fail
+        Then naemon should fail to start
+
+    Scenario: Naemon fails to daemonize when an invalid object config is
+        provided
+        Given I have an invalid naemon object configuration
+        And config verification fail
+        Then naemon should fail to start
+
+    Scenario: Naemon fails to daemonize when all config provided is invalid
+        Given I have an invalid naemon object configuration
+        And I have an invalid naemon system configuration
+        And config verification fail
+        Then naemon should fail to start
+
+    Scenario: Naemon successfully daemonizes when a valid config is provided
+        Given config verification pass
+        Then naemon should successfully start
+

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,47 @@
+from support.naemon_object_config import NaemonObjectConfig
+from support.naemon_system_config import NaemonSystemConfig
+import tempfile
+import os.path
+import signal
+import shutil
+
+
+def before_all(context):
+    os.environ['LD_LIBRARY_PATH'] = (
+        os.getcwd() + '/' + context.config.userdata['shared_libs_path']
+    )
+
+
+def before_scenario(context, scenario):
+    context.wrkdir = os.getcwd()
+    context.tmpdir = tempfile.mkdtemp()
+    assert os.path.exists(context.tmpdir) is not False, (
+        'Failed to create a temporary directory'
+    )
+    print ('Changing directory to %s from %s' % (
+            context.tmpdir, context.wrkdir
+        )
+    )
+    os.chdir(context.tmpdir)
+    context.naemonsysconfig = NaemonSystemConfig()
+    context.naemonobjconfig = NaemonObjectConfig()
+
+
+def after_scenario(context, scenario):
+    # Kill any naemon daemonsv
+    if os.path.isfile('naemon.pid'):
+        pid = int(open('naemon.pid').read())
+        try:
+            os.kill(pid, signal.SIGTERM)
+            print ('Killed the naemon process (%i)' % pid)
+        except OSError as e:
+            print (os.strerror(e.errno))
+            pass
+    print ('Changing directory to %s from %s' % (
+            context.wrkdir, context.tmpdir
+        )
+    )
+    os.chdir(context.wrkdir)
+    if scenario.status != 'failed':
+        print ('Deleting temporary directory %s' % context.tmpdir)
+        shutil.rmtree(context.tmpdir, True)

--- a/features/steps/filesystem.py
+++ b/features/steps/filesystem.py
@@ -1,0 +1,13 @@
+from behave import given, use_step_matcher
+import os.path
+
+use_step_matcher('re')
+
+
+@given('I have directory (?P<directory>.+)')
+def create_directory(context, directory):
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+    assert os.path.exists(directory) is not False, (
+        'Failed to create directory (%s)' % directory
+    )

--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -1,0 +1,89 @@
+from behave import given, when, then, use_step_matcher
+import subprocess
+
+use_step_matcher('re')
+
+
+@given('I have naemon (?P<object_type>.+) objects')
+def add_naemon_object(context, object_type):
+    print ("Object type %s" % object_type)
+    for row in context.table:
+        context.naemonobjconfig.add_obj(object_type, context.table)
+
+
+@given('I have naemon config (?P<parameter>.+) set to (?P<value>.+)')
+def set_naemon_parameter(context, parameter, value):
+    context.naemonsysconfig.set_var(parameter, value)
+
+
+@given('I have an invalid naemon system configuration')
+def invalid_sysconfig(context):
+    context.execute_steps(u'Given I have naemon config invalid_param set to x')
+
+
+@given('I have an invalid naemon object configuration')
+def invalid_objconfig(context):
+    context.execute_steps(u'''
+        Given I have naemon host objects
+            | use          | host_name    | address   | check_command |
+            | default-host | invalid_host | 127.0.0.1 | non_existing  |
+    ''')
+
+
+@given('I write config to file')
+def configuration_to_file(context):
+    context.naemonobjconfig.to_file(context.naemonobjconfig.filename)
+    context.naemonsysconfig.to_file(context.naemonsysconfig.filename)
+    context.execute_steps(u'Given I have directory checkresults')
+
+
+@given('I verify the naemon configuration')
+def config_verification(context):
+    context.execute_steps(u'Given I write config to file')
+    executable = (
+        context.wrkdir + '/' + context.config.userdata['naemon_exec_path']
+    )
+    args = [executable, '--allow-root', '-v', context.naemonsysconfig.filename]
+    context.return_code = subprocess.call(args)
+
+
+@given('config verification fail')
+def config_verification_fail(context):
+    context.execute_steps(u'Given I verify the naemon configuration')
+    assert context.return_code != 0, (
+        'Return code was %s' % context.return_code
+    )
+
+
+@given('config verification pass')
+def config_verification_pass(context):
+    context.execute_steps(u'Given I verify the naemon configuration')
+    assert context.return_code == 0, (
+        'Return code was not 0 (got %s)' % context.return_code
+    )
+
+
+@when('I start naemon')
+def naemon_start(context):
+    context.execute_steps(u'Given I write config to file')
+    executable = (
+        context.wrkdir + '/' + context.config.userdata['naemon_exec_path']
+    )
+    args = [executable, '--allow-root', '-d', context.naemonsysconfig.filename]
+    context.return_code = subprocess.call(args)
+
+
+@then('naemon should fail to start')
+def naemon_start_fail(context):
+    context.execute_steps(u'When I start naemon')
+    assert context.return_code != 0, (
+        'Return code was %s' % context.return_code
+    )
+
+
+@then('naemon should successfully start')
+def naemon_start_success(context):
+    context.execute_steps(u'When I start naemon')
+    assert context.return_code == 0, (
+        'Return code was not 0 (got %s)' % context.return_code
+    )

--- a/features/support/naemon_object_config.py
+++ b/features/support/naemon_object_config.py
@@ -1,0 +1,102 @@
+class NaemonObjectConfig(object):
+
+    filename = 'oconf.cfg'
+
+    def __init__(self):
+        self.current_config = {
+            'contact': [{
+                'name': 'default-contact',
+                'contact_name': 'default-contact',
+                'host_notifications_enabled': '1',
+                'service_notifications_enabled': '1',
+                'host_notification_period': '24x7',
+                'service_notification_period': '24x7',
+                'host_notification_options': 'a',
+                'service_notification_options': 'a',
+                'host_notification_commands': 'dummy_command',
+                'service_notification_commands': 'dummy_command',
+            }],
+            'timeperiod': [{
+                'timeperiod_name': '24x7',
+                'alias': '24x7',
+                'sunday': '00:00-24:00',
+                'monday': '00:00-24:00',
+                'tuesday': '00:00-24:00',
+                'wednesday': '00:00-24:00',
+                'thursday': '00:00-24:00',
+                'friday': '00:00-24:00',
+                'saturday': '00:00-24:00'
+            }],
+            'command': [{
+                'command_name': 'dummy_command',
+                'command_line': 'exit 0'
+            }],
+            'host': [{
+                'check_command': 'dummy_command',
+                'max_check_attempts': 3,
+                'check_interval': 5,
+                'retry_interval': 0,
+                'obsess': 0,
+                'check_freshness': 0,
+                'active_checks_enabled': 0,
+                'passive_checks_enabled': 1,
+                'event_handler_enabled': 1,
+                'flap_detection_enabled': 1,
+                'process_perf_data': 1,
+                'retain_status_information': 1,
+                'retain_nonstatus_information': 1,
+                'notification_interval': 0,
+                'notification_options': 'a',
+                'notifications_enabled': 1,
+                'register': 0,
+                'name': 'default-host',
+            }],
+            'service': [{
+                'is_volatile': 0,
+                'max_check_attempts': 3,
+                'check_interval': 5,
+                'check_command': 'dummy_command',
+                'retry_interval': 1,
+                'active_checks_enabled': 0,
+                'passive_checks_enabled': 1,
+                'check_period': '24x7',
+                'parallelize_check': 0,
+                'obsess': 0,
+                'check_freshness': 0,
+                'event_handler_enabled': 1,
+                'flap_detection_enabled': 1,
+                'process_perf_data': 1,
+                'retain_status_information': 1,
+                'retain_nonstatus_information': 1,
+                'notification_interval': 0,
+                'notification_period': '24x7',
+                'notification_options': 'a',
+                'notifications_enabled': 1,
+                'register': 0,
+                'name': 'default-service'
+            }]
+        }
+
+    def add_obj(self, object_type, parameters):
+        if object_type not in self.current_config:
+            self.current_config[object_type] = []
+        object = dict()
+        for row in parameters:
+            for heading in row.headings:
+                object[heading] = row[heading]
+        self.current_config[object_type].append(object)
+
+    def to_string(self):
+        res = ""
+        for type, objects in self.current_config.items():
+            for object in objects:
+                res += ('define %s {\n' % (type))
+                for key, value in object.items():
+                    res += ('\t%s\t%s\n' % (key, value))
+                res += ('}\n\n')
+        return res
+
+    def to_file(self, filename):
+        f = open(filename, 'w')
+        f.write(self.to_string())
+        f.close()

--- a/features/support/naemon_system_config.py
+++ b/features/support/naemon_system_config.py
@@ -1,0 +1,34 @@
+class NaemonSystemConfig(object):
+
+    filename = 'naemon.cfg'
+
+    def __init__(self):
+        self.current_config = {
+            'query_socket': 'naemon.qh',
+            'check_result_path': 'checkresults',
+            'event_broker_options': '-1',
+            'command_file': 'naemon.cmd',
+            'object_cache_file': 'objects.cache',
+            'status_file': 'status_file.sav',
+            'log_file': 'naemon.log',
+            'retain_state_information': '1',
+            'state_retention_file': 'status.sav',
+            'execute_host_checks': '0',
+            'execute_service_checks': '0',
+            'cfg_file': 'oconf.cfg',
+            'lock_file': 'naemon.pid'
+        }
+
+    def set_var(self, name, value):
+        self.current_config[name] = value
+
+    def to_string(self):
+        res = ''
+        for key, value in self.current_config.items():
+            res += ("%s=%s\n" % (key, value))
+        return res
+
+    def to_file(self, filename):
+        f = open(filename, 'w')
+        f.write(self.to_string())
+        f.close()

--- a/naemon-query.py
+++ b/naemon-query.py
@@ -1,73 +1,78 @@
 #!/usr/bin/env python
 
-import sys, os, socket
+import sys
+import socket
+
 
 class naemon_qh:
-	__slots__ = ['query_handler', 'socket', 'read_size']
-	read_size = 4096
-	socket = False
-	query_handler = False
+    __slots__ = ['query_handler', 'socket', 'read_size']
+    read_size = 4096
+    socket = False
+    query_handler = False
 
-	def __init__(self, query_handler):
-		self.query_handler = query_handler
+    def __init__(self, query_handler):
+        self.query_handler = query_handler
 
-	def query(self, query):
-		"""Ask a raw query to naemon' query handler socket, return the raw
-		response as a lazily generated sequence."""
-		if not query:
-			print "Missing query argument"
-			return
-		try:
-			self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-			self.socket.connect(self.query_handler)
+    def query(self, query):
+        """Ask a raw query to naemon' query handler socket, return the raw
+        response as a lazily generated sequence."""
+        if not query:
+            print "Missing query argument"
+            return
+        try:
+            self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self.socket.connect(self.query_handler)
 
-			self.socket.send(query + '\0')
-			while True:
-				try:
-					out = self.socket.recv(self.read_size)
-					if not out:
-						break
-					yield out
-				except KeyboardInterrupt:
-					print "Good bye."
-					break
-			self.socket.close()
-		except socket.error, e:
-			print "Couldn't connect to naemon socket %s: %s" % (self.query_handler, str(e))
+            self.socket.send(query + '\0')
+            while True:
+                try:
+                    out = self.socket.recv(self.read_size)
+                    if not out:
+                        break
+                    yield out
+                except KeyboardInterrupt:
+                    print "Good bye."
+                    break
+            self.socket.close()
+        except socket.error, e:
+            print ("Couldn't connect to naemon socket %s: %s" % (
+                    self.query_handler, str(e)
+                )
+            )
 
-	def format(self, data, rowsep='\n', pairsep=';', kvsep='='):
-		"""Lazily format a response into a sequence of dicts"""
-		def todict(row):
-			return dict(x.split(kvsep) for x in row.split(pairsep))
-		rest = ''
-		for block in data:
-			block = rest + block
-			rows = block.split(rowsep)
-			for row in rows[:-1]:
-				yield todict(row)
-			rest = rows[-1]
-		if rest:
-			yield todict(rest)
+    def format(self, data, rowsep='\n', pairsep=';', kvsep='='):
+        """Lazily format a response into a sequence of dicts"""
+        def todict(row):
+            return dict(x.split(kvsep) for x in row.split(pairsep))
+        rest = ''
+        for block in data:
+            block = rest + block
+            rows = block.split(rowsep)
+            for row in rows[:-1]:
+                yield todict(row)
+            rest = rows[-1]
+        if rest:
+            yield todict(rest)
 
-	def get(self, query, rowsep='\n', pairsep=';', kvsep='='):
-		"""Ask a query to naemon' query handler socket, and return an object
-		representing a "standard" naemon qh response"""
-		resp = self.query(query)
-		return self.format(resp, rowsep, pairsep, kvsep)
+    def get(self, query, rowsep='\n', pairsep=';', kvsep='='):
+        """Ask a query to naemon' query handler socket, and return an object
+        representing a "standard" naemon qh response"""
+        resp = self.query(query)
+        return self.format(resp, rowsep, pairsep, kvsep)
 
 
 if __name__ == '__main__':
-	socket_path = '/var/lib/naemon/naemon.qh'
-	query_args = []
+    socket_path = '/var/lib/naemon/naemon.qh'
+    query_args = []
 
-	for arg in sys.argv[1:]:
-		if arg.startswith('--socket='):
-			socket_path = arg.split('=', 1)[1]
-			continue
-		query_args.append(arg)
+    for arg in sys.argv[1:]:
+        if arg.startswith('--socket='):
+            socket_path = arg.split('=', 1)[1]
+            continue
+        query_args.append(arg)
 
-	query = ' '.join(query_args)
-	qh = naemon_qh(socket_path)
-	for block in qh.query(query):
-		sys.stdout.write(block)
-		sys.stdout.flush()
+    query = ' '.join(query_args)
+    qh = naemon_qh(socket_path)
+    for block in qh.query(query):
+        sys.stdout.write(block)
+        sys.stdout.flush()

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -1,11 +1,20 @@
 post:
-    steps: |
-        service naemon start
-        service naemon restart
-        service naemon reload
-        service naemon stop
-        service naemon start
-        kill -9 \`cat /var/cache/naemon/naemon.pid\`
-        service naemon start
-        service naemon stop
-        service naemon start
+  install:
+    - python-pip
+  steps: |
+    service naemon start
+    service naemon restart
+    service naemon reload
+    service naemon stop
+    service naemon start
+    kill -9 \`cat /var/cache/naemon/naemon.pid\`
+    service naemon start
+    service naemon stop
+    service naemon start
+
+    # Run behave tests
+    if [ -f /usr/bin/systemctl ]; then
+      pip install behave flake8
+      flake8
+      behave -o behave.log
+    fi

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -656,6 +656,15 @@ int main(int argc, char **argv)
 		nm_free(mac->x[MACRO_EVENTSTARTTIME]);
 		nm_asprintf(&mac->x[MACRO_EVENTSTARTTIME], "%lu", (unsigned long)event_start);
 
+		/* let the parent know we're good to go and that it can let go */
+		if (daemon_mode == TRUE && sigrestart == FALSE) {
+			if ((result = signal_parent(OK)) != OK) {
+				broker_program_state(NEBTYPE_PROCESS_SHUTDOWN, NEBFLAG_PROCESS_INITIATED, NEBATTR_SHUTDOWN_ABNORMAL);
+				cleanup();
+				exit(ERROR);
+			}
+		}
+
 		timing_point("Entering event execution loop\n");
 		/***** start monitoring all services *****/
 		/* (doesn't return until a restart or shutdown signal is encountered) */

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -44,6 +44,7 @@ char *check_result_path = NULL;
 char *lock_file = NULL;
 objectlist *objcfg_files = NULL;
 objectlist *objcfg_dirs = NULL;
+int upipe_fd[2];
 
 int num_check_workers = 0; /* auto-decide */
 char *qh_socket_path = NULL; /* disabled */
@@ -314,9 +315,8 @@ void sighandler(int sig)
 	case SIGTERM: /* fallthrough */
 	case SIGINT: /* fallthrough */
 	case SIGPIPE: sigshutdown = TRUE; break;
+	case SIGCHLD: exit(EXIT_FAILURE); /* Daemon child died */
 	}
-
-
 }
 
 void signal_react() {
@@ -479,6 +479,16 @@ static int set_working_directory(void)
 	return (OK);
 }
 
+int signal_parent(int sig)
+{
+	if (write(upipe_fd[PIPE_WRITE], &sig, sizeof(int)) < 0) {
+		nm_log(NSLOG_RUNTIME_ERROR, "Failed to signal parent: %s",
+			strerror(errno));
+		return ERROR;
+	}
+	return OK;
+}
+
 int daemon_init(void)
 {
 	int pid = 0;
@@ -535,14 +545,62 @@ int daemon_init(void)
 			return (ERROR);
 		}
 	}
-	if ((pid = (int)fork()) < 0)
+
+	/*
+	 * set up a pipe used for sending a message from the child to the parent
+	 * when initialization is complete.
+	 */
+	if (pipe(upipe_fd) < 0) {
+		nm_log(NSLOG_RUNTIME_ERROR, "Failed to set up unnamned pipe: %s",
+			strerror(errno));
 		return (ERROR);
+	}
 
-	/* parent process goes away.. */
-	else if (pid != 0)
-		exit(OK);
+	/*
+	 * as a parent and if the child dies during initialization, we need to exit
+	 * so we don't get stuck in an endless wait for input.
+	 */
+	if (signal(SIGCHLD, sighandler) == SIG_ERR) {
+		nm_log(NSLOG_RUNTIME_ERROR, "Failed to set up daemonization signal: %s",
+			strerror(errno));
+		return (ERROR);
+	}
 
-	/* child continues... */
+	if ((pid = (int)fork()) < 0) {
+		nm_log(NSLOG_RUNTIME_ERROR, "Unable to fork out the daemon process: %s",
+			strerror(errno));
+		return (ERROR);
+	} else if (pid != 0) {
+		/* parent stops - when child is done, we exit here */
+		int return_code = OK;
+		if (close(upipe_fd[PIPE_WRITE]) < 0) {
+			nm_log(NSLOG_RUNTIME_ERROR, "Unable to close parent write end: %s",
+				strerror(errno));
+			return_code = EXIT_FAILURE;
+		}
+		if (read(upipe_fd[PIPE_READ], &return_code, sizeof(int)) < 0) {
+			nm_log(NSLOG_RUNTIME_ERROR, "Unable to read from pipe: %s",
+				strerror(errno));
+			return_code = EXIT_FAILURE;
+		}
+		if (close(upipe_fd[PIPE_READ]) < 0) {
+			nm_log(NSLOG_RUNTIME_ERROR, "Unable to close parent read end: %s",
+				strerror(errno));
+			return_code = EXIT_FAILURE;
+		}
+		if (return_code != OK) {
+			/* signal the child to die in case an error occurs in parent */
+			kill(pid, SIGTERM);
+		}
+		exit(return_code);
+	} else {
+		/* close read end of the pipe in the child */
+		if (close(upipe_fd[PIPE_READ]) < 0) {
+			nm_log(NSLOG_RUNTIME_ERROR, "Unable to close child read end: %s",
+				strerror(errno));
+			return ERROR;
+		}
+	}
 
 	/* child becomes session leader... */
 	setsid();

--- a/src/naemon/utils.h
+++ b/src/naemon/utils.h
@@ -15,6 +15,8 @@
 NAGIOS_BEGIN_DECL
 
 #define CHECK_STATS_BUCKETS                  15
+#define PIPE_READ                             0
+#define PIPE_WRITE                            1
 
 /* used for tracking host and service check statistics */
 typedef struct check_stats {
@@ -33,6 +35,7 @@ void setup_sighandler(void);                         		/* trap signals */
 void reset_sighandler(void);                         		/* reset signals to default action */
 void signal_react(void);				/* General signal reaction routines */
 void handle_sigxfsz(void);				/* handle SIGXFSZ */
+int signal_parent(int);					/* signal parent when daemonizing */
 int daemon_init(void);				     		/* switches to daemon mode */
 
 int init_check_stats(void);


### PR DESCRIPTION
Doing configuration changes in a large environments with big configuration files and then restarting naemon will take a very long time. We would like to remove all verification done when starting and restarting and make configuration verification explicit through `naemon -v`.

This patch removes the verification done in the init script. It also makes the parent wait for the child to be fully initialized before exiting the parent when daemonizing, making it possible to catch if the child fails during the initialization.