### PR TITLE
reduce log spam

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -408,8 +408,6 @@ int update_host_state_post_check(struct host *hst, struct check_result *cr)
 	/* adjust return code (active checks only) */
 	if (cr->check_type == CHECK_TYPE_ACTIVE) {
 		if (cr->early_timeout) {
-			nm_log(NSLOG_RUNTIME_WARNING,
-			       "Warning: Check of host '%s' timed out after %.2lf seconds\n", hst->name, hst->execution_time);
 			nm_free(hst->plugin_output);
 			nm_free(hst->long_plugin_output);
 			nm_free(hst->perf_data);

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -437,8 +437,6 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	nm_free(temp_service->perf_data);
 
 	if (queued_check_result->early_timeout == TRUE) {
-		nm_log(NSLOG_RUNTIME_WARNING,
-		       "Warning: Check of service '%s' on host '%s' timed out after %.3fs!\n", temp_service->description, temp_service->host_name, temp_service->execution_time);
 		nm_asprintf(&temp_service->plugin_output, "(Service check timed out after %.2lf seconds)", temp_service->execution_time);
 		temp_service->current_state = service_check_timeout_state;
 	}

--- a/src/naemon/workers.c
+++ b/src/naemon/workers.c
@@ -459,7 +459,7 @@ static int handle_worker_result(int sd, int events, void *arg)
 
 		/* log messages are handled first */
 		if (size > 5 && !memcmp(buf, "log=", 4)) {
-			nm_log(NSLOG_INFO_MESSAGE, "wproc: %s: %s\n", wp->name, buf + 4);
+			log_debug_info(DEBUGL_IPC, DEBUGV_BASIC, "wproc: %s: %s\n", wp->name, buf + 4);
 			nm_free(buf);
 			continue;
 		}
@@ -544,7 +544,7 @@ static int register_worker(int sd, char *buf, unsigned int len)
 
 	g_return_val_if_fail(specialized_workers != NULL, ERROR);
 
-	nm_log(NSLOG_INFO_MESSAGE, "wproc: Registry request: %s\n", buf);
+	log_debug_info(DEBUGL_IPC, DEBUGV_BASIC, "wproc: Registry request: %s\n", buf);
 	worker = nm_calloc(1, sizeof(*worker));
 	info = buf2kvvec(buf, len, '=', ';', 0);
 	if (info == NULL) {
@@ -676,7 +676,7 @@ int init_workers(int desired_workers)
 			free, NULL
 			);
 	if (!qh_register_handler("wproc", "Worker process management and info", 0, wproc_query_handler)) {
-		nm_log(NSLOG_INFO_MESSAGE, "wproc: Successfully registered manager as @wproc with query handler\n");
+		log_debug_info(DEBUGL_IPC, DEBUGV_BASIC, "wproc: Successfully registered manager as @wproc with query handler\n");
 	} else {
 		nm_log(NSLOG_RUNTIME_ERROR, "wproc: Failed to register manager with query handler\n");
 		return -1;


### PR DESCRIPTION
Do not log timeouts 3 times for each timeout. Timeouts are a normal thing in
monitoring and state changes are logged already, there is no need to add 2
extra log entries, one from wproc and one from the check handler. Especially since
the timeout is quite visible already and the extra logging does not add any value.

Signed-off-by: Sven Nierlein <sven@nierlein.de>