### PR TITLE
naemon executable path

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -7,9 +7,16 @@ import shutil
 
 
 def before_all(context):
-    os.environ['LD_LIBRARY_PATH'] = (
-        os.getcwd() + '/' + context.config.userdata['shared_libs_path']
-    )
+    # check if we have set relative paths in behave.ini
+    if 'shared_libs_path' in context.config.userdata:
+        os.environ['LD_LIBRARY_PATH'] = \
+            os.path.abspath(context.config.userdata['shared_libs_path'])
+
+    # use naemon executable defined in PATH if nothing else is given
+    context.naemon_exec_path = 'naemon'
+    if 'naemon_exec_path' in context.config.userdata:
+        context.naemon_exec_path = \
+            os.path.abspath(context.config.userdata['naemon_exec_path'])
 
 
 def before_scenario(context, scenario):

--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -40,10 +40,8 @@ def configuration_to_file(context):
 @given('I verify the naemon configuration')
 def config_verification(context):
     context.execute_steps(u'Given I write config to file')
-    executable = (
-        context.wrkdir + '/' + context.config.userdata['naemon_exec_path']
-    )
-    args = [executable, '--allow-root', '-v', context.naemonsysconfig.filename]
+    args = [context.naemon_exec_path, '--allow-root', '--verify-config',
+            context.naemonsysconfig.filename]
     context.return_code = subprocess.call(args)
 
 
@@ -66,10 +64,8 @@ def config_verification_pass(context):
 @when('I start naemon')
 def naemon_start(context):
     context.execute_steps(u'Given I write config to file')
-    executable = (
-        context.wrkdir + '/' + context.config.userdata['naemon_exec_path']
-    )
-    args = [executable, '--allow-root', '-d', context.naemonsysconfig.filename]
+    args = [context.naemon_exec_path, '--allow-root', '--daemon',
+            context.naemonsysconfig.filename]
     context.return_code = subprocess.call(args)
 
 

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -16,5 +16,5 @@ post:
     if [ -f /usr/bin/systemctl ]; then
       pip install behave flake8
       flake8
-      behave -o behave.log
+      behave -o behave.log -D naemon_exec_path=/usr/bin/naemon -D shared_libs_path=/usr/lib64/
     fi


### PR DESCRIPTION
Added ability to omit setting the executable path to the
naemon binary and the shared libraries. Also added possibility
to use absolute paths.

Signed-off-by: Robin Engström <robin.engstrom@op5.com>