### PR TITLE
Feature/more timing points

### DIFF
--- a/src/naemon/shared.c
+++ b/src/naemon/shared.c
@@ -2,12 +2,9 @@
 #include "common.h"
 #include "defaults.h"
 #include "nm_alloc.h"
-#include "logging.h"
-#include <assert.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -63,31 +60,24 @@ void timing_point(const char *fmt, ...)
 	static struct timeval last = {0, 0}, first = {0, 0};
 	struct timeval now;
 	va_list ap;
-	char *applied_format;
 
 	if (!enable_timing_point)
 		return;
-
-	va_start(ap, fmt);
-	if (vasprintf(&applied_format, fmt, ap) == -1) {
-		nm_log(NSLOG_RUNTIME_ERROR, "Couldn't allocate memory in timing_poing");
-		abort();
-	}
-	va_end(ap);
 
 	if (first.tv_sec == 0) {
 		gettimeofday(&first, NULL);
 		last.tv_sec = first.tv_sec;
 		last.tv_usec = first.tv_usec;
-		nm_log(NSLOG_INFO_MESSAGE, "Timing point: [0.0000 (+0.0000)] %s", applied_format);
+		printf("[0.0000 (+0.0000)] ");
 	} else {
 		gettimeofday(&now, NULL);
-		nm_log(NSLOG_INFO_MESSAGE, "Timing point: [%.4f (+%.4f)] %s", tv_delta_f(&first, &now), tv_delta_f(&last, &now), applied_format);
+		printf("[%.4f (+%.4f)] ", tv_delta_f(&first, &now), tv_delta_f(&last, &now));
 		last.tv_sec = now.tv_sec;
 		last.tv_usec = now.tv_usec;
 	}
-
-	free(applied_format);
+	va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
 }
 
 


### PR DESCRIPTION
I think more and tighter timing points will be good when measuring performance in large monitoring clusters.

Example of ouput:
```
[1494399523] Timing point: [0.0001 (+0.0001)] Reset variables
[1494399523] Timing point: [0.0002 (+0.0001)] Reading main config file
[1494399523] Timing point: [0.0007 (+0.0005)] Read main config file
[1494399523] Timing point: [0.0011 (+0.0004)] Initializing NEB module API
[1494399523] Timing point: [0.0011 (+0.0000)] Initialized NEB module API
[1494399523] Timing point: [0.0011 (+0.0000)] Initializing Query handler
[1494399523] Timing point: [0.0012 (+0.0001)] Initialized Query handler
[1494399523] Timing point: [0.0012 (+0.0000)] Initializing NERD
[1494399523] Timing point: [0.0013 (+0.0000)] Initialized NERD
[1494399523] Timing point: [0.0013 (+0.0000)] Spawning 0 workers
[1494399523] Timing point: [0.0019 (+0.0006)] Spawned 6 workers
[1494399523] Timing point: [0.0019 (+0.0001)] Connecting 0 workers
[1494399523] Timing point: [0.0036 (+0.0017)] Connected 6 workers
[1494399523] Timing point: [0.0037 (+0.0000)] Reading all object data
[1494399523] Timing point: [0.0037 (+0.0000)] Reading config data from '/opt/monitor/etc/naemon.cfg'
[1494399524] Timing point: [0.4650 (+0.4613)] Done parsing config files
[1494399524] Timing point: [0.4969 (+0.0319)] Done resolving objects
[1494399524] Timing point: [0.5022 (+0.0054)] Done recombobulating contactgroups
[1494399524] Timing point: [0.5066 (+0.0044)] Done recombobulating hostgroups
[1494399524] Timing point: [0.6150 (+0.1084)] Created 160082 services (dupes possible)
[1494399524] Timing point: [0.6189 (+0.0039)] Done recombobulating servicegroups
[1494399524] Timing point: [0.6190 (+0.0001)] Created 0 hostescalations (dupes possible)
[1494399524] Timing point: [0.6190 (+0.0000)] Created 0 serviceescalations (dupes possible)
[1494399524] Timing point: [0.6191 (+0.0000)] Done merging hostextinfo
[1494399524] Timing point: [0.6191 (+0.0000)] Done merging serviceextinfo
[1494399524] Timing point: [0.6367 (+0.0176)] Done propagating inherited object properties
[1494399524] Timing point: [0.8314 (+0.1947)] 0 unique / 0 total servicedependencies registered
[1494399524] Timing point: [0.8315 (+0.0001)] 0 serviceescalations registered
[1494399524] Timing point: [0.8315 (+0.0000)] 0 unique / 0 total hostdependencies registered
[1494399524] Timing point: [0.8315 (+0.0000)] 0 hostescalations registered
[1494399524] Timing point: [0.8528 (+0.0213)] Read all object data
[1494399524] Timing point: [0.8693 (+0.0165)] Initializing Event queue
[1494399524] Timing point: [0.8729 (+0.0036)] Initialized Event queue
[1494399524] Timing point: [0.8730 (+0.0001)] Loading modules
[1494399524] Timing point: [1.0832 (+0.2102)] Loaded modules
[1494399524] Timing point: [1.0832 (+0.0000)] Making first callback
[1494399524] Timing point: [1.0832 (+0.0000)] Made first callback
[1494399524] Timing point: [1.0832 (+0.0000)] Running pre flight check
[1494399526] Timing point: [2.5725 (+1.4892)] Ran pre flight check
[1494399526] Timing point: [2.5725 (+0.0000)] Caching objects
[1494399527] Timing point: [3.3357 (+0.7632)] Cached objects
[1494399530] Timing point: [6.2743 (+2.9387)] Initializing status data
[1494399530] Timing point: [6.2928 (+0.0185)] Initialized status data
[1494399530] Timing point: [6.2929 (+0.0001)] Initializing downtime data
[1494399530] Timing point: [6.2929 (+0.0000)] Initialized downtime data
[1494399530] Timing point: [6.2929 (+0.0000)] Initializing retention data
[1494399530] Timing point: [6.2931 (+0.0001)] Initialized retention data
[1494399530] Timing point: [6.2931 (+0.0000)] Reading initial state information
[1494399532] Timing point: [8.3981 (+2.1050)] Read initial state information
[1494399532] Timing point: [8.3996 (+0.0015)] Initializing comment data
[1494399532] Timing point: [8.3997 (+0.0000)] Initialized comment data
[1494399532] Timing point: [8.3997 (+0.0000)] Initializing performance data
[1494399532] Timing point: [8.3997 (+0.0000)] Initialized performance data
[1494399532] Timing point: [8.3997 (+0.0000)] Initializing check execution scheduling
[1494399532] Timing point: [8.4696 (+0.0699)] Initialized check execution scheduling
[1494399532] Timing point: [8.4697 (+0.0001)] Initializing check stats
[1494399532] Timing point: [8.4697 (+0.0000)] Initialized check stats
[1494399532] Timing point: [8.4697 (+0.0000)] Updating status data
[1494399535] Timing point: [11.3166 (+2.8469)] Updated status data
[1494399535] Timing point: [11.3167 (+0.0001)] Logging initial states
[1494399536] Timing point: [12.8815 (+1.5648)] Logged initial states
[1494399536] Timing point: [12.8818 (+0.0003)] Launching command file worker
[1494399536] Timing point: [12.8837 (+0.0019)] Launched command file worker
[1494399536] Timing point: [12.9027 (+0.0190)] Entering event execution loop
```