### PR TITLE
Fixes memory leak for DATE/TIME Macros

### DIFF
--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -584,18 +584,19 @@ int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *
 		break;
 
 	case MACRO_TIMET:
-		*output = (char *)mkstr("%lu", (unsigned long)current_time);
+		asprintf(&*output, "%lu", (unsigned long)current_time);
 		break;
 
 	case MACRO_ISVALIDTIME:
-		*output = (char *)mkstr("%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
+		//*output = (char *)mkstr("%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
+		asprintf(&*output, "%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
 		break;
 
 	case MACRO_NEXTVALIDTIME:
 		get_next_valid_time(test_time, &next_valid_time, temp_timeperiod);
 		if (next_valid_time == test_time && check_time_against_period(test_time, temp_timeperiod) == ERROR)
 			next_valid_time = (time_t)0L;
-		*output = (char *)mkstr("%lu", (unsigned long)next_valid_time);
+		asprintf(&*output, "%lu", (unsigned long)next_valid_time);
 		break;
 
 	default:
@@ -1890,6 +1891,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 
 		/* calculate macros */
 		result = grab_datetime_macro_r(mac, macro_type, arg1, arg2, output);
+		*free_macro = TRUE;
 		break;
 
 		/*****************/

--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -584,18 +584,18 @@ int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *
 		break;
 
 	case MACRO_TIMET:
-		asprintf(&*output, "%lu", (unsigned long)current_time);
+		nm_asprintf(output, "%lu", (unsigned long)current_time);
 		break;
 
 	case MACRO_ISVALIDTIME:
-		asprintf(&*output, "%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
+		nm_asprintf(output, "%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
 		break;
 
 	case MACRO_NEXTVALIDTIME:
 		get_next_valid_time(test_time, &next_valid_time, temp_timeperiod);
 		if (next_valid_time == test_time && check_time_against_period(test_time, temp_timeperiod) == ERROR)
 			next_valid_time = (time_t)0L;
-		asprintf(&*output, "%lu", (unsigned long)next_valid_time);
+		nm_asprintf(output, "%lu", (unsigned long)next_valid_time);
 		break;
 
 	default:

--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -588,7 +588,6 @@ int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *
 		break;
 
 	case MACRO_ISVALIDTIME:
-		//*output = (char *)mkstr("%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
 		asprintf(&*output, "%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
 		break;
 


### PR DESCRIPTION
 The DATE / TIME macros were not freeing the allocated pointer.
 I had to swap mkstr for asprintf in order to be able to free the pointer outside the function.