### PR TITLE
Allow circular dependencies for host graph

### DIFF
--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -1017,6 +1017,10 @@ allow_empty_hostgroup_assignment=0
 
 # CIRCULAR DEPENDENCIES (EXPERIMENTAL)
 # Allow for circular dependencies in naemon's host graph.
+# Enabaling this will cause propagation the following to stop working:
+# * scheduling downtime
+# * enabling notification
+# * disabling notification
 # This feature is experimental and bugs might occur.
 
 allow_circular_dependencies=0

--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -1017,10 +1017,9 @@ allow_empty_hostgroup_assignment=0
 
 # CIRCULAR DEPENDENCIES (EXPERIMENTAL)
 # Allow for circular dependencies in naemon's host graph.
-# Enabaling this will cause propagation the following to stop working:
-# * scheduling downtime
-# * enabling notification
-# * disabling notification
+# Enabling this will cause following to stop working:
+# * scheduling and propagating downtime
+# * enabling/disabling and propagation notifications
 # This feature is experimental and bugs might occur.
 
 allow_circular_dependencies=0

--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -1014,3 +1014,9 @@ allow_empty_hostgroup_assignment=0
 # with a minimum of 4 workers.  This value will override the defaults
 
 #check_workers=3
+
+# CIRCULAR DEPENDENCIES (EXPERIMENTAL)
+# Allow for circular dependencies in naemon's host graph.
+# This feature is experimental and bugs might occur.
+
+allow_circular_dependencies=0

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -3810,10 +3810,6 @@ static void enable_and_propagate_notifications(host *hst, struct propagation_par
 	if (params->affect_top_host == TRUE && params->level == 0)
 		enable_host_notifications(hst);
 
-	/* if we allow circular dependencies, this function doesn't work */
-	if (allow_circular_dependencies)
-		return;
-
 	g_tree_foreach(hst->child_hosts, enable_and_propagate_notifications_cb, params);
 }
 

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -3802,9 +3802,17 @@ static gboolean enable_and_propagate_notifications_cb(gpointer _name, gpointer _
 /* enables notifications for all hosts and services "beyond" a given host */
 static void enable_and_propagate_notifications(host *hst, struct propagation_parameters *params)
 {
+	/* if we allow circular dependencies, this function doesn't work */
+	if (allow_circular_dependencies)
+		return;
+
 	/* enable notification for top level host */
 	if (params->affect_top_host == TRUE && params->level == 0)
 		enable_host_notifications(hst);
+
+	/* if we allow circular dependencies, this function doesn't work */
+	if (allow_circular_dependencies)
+		return;
 
 	g_tree_foreach(hst->child_hosts, enable_and_propagate_notifications_cb, params);
 }
@@ -3839,6 +3847,10 @@ static gboolean disable_and_propagate_notifications_cb(gpointer _name, gpointer 
 static void disable_and_propagate_notifications(host *hst, struct propagation_parameters *params)
 {
 	if (hst == NULL)
+		return;
+
+	/* if we allow circular dependencies, this function doesn't work */
+	if (allow_circular_dependencies)
 		return;
 
 	/* disable notifications for top host */
@@ -3969,6 +3981,10 @@ static gboolean schedule_and_propagate_downtime_cb(gpointer _name, gpointer _hst
 /* schedules downtime for all hosts "beyond" a given host */
 static void schedule_and_propagate_downtime(host *temp_host, struct downtime_parameters *params)
 {
+	/* if we allow circular dependencies, this function doesn't work */
+	if (allow_circular_dependencies)
+		return;
+
 	g_tree_foreach(temp_host->child_hosts, schedule_and_propagate_downtime_cb, params);
 }
 

--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -1041,6 +1041,8 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			object_precache_file = nspath_absolute(value, config_file_dir);
 		} else if (!strcmp(variable, "allow_empty_hostgroup_assignment")) {
 			allow_empty_hostgroup_assignment = (atoi(value) > 0) ? TRUE : FALSE;
+		} else if (!strcmp(variable, "allow_circular_dependencies")) {
+			allow_circular_dependencies=atoi(value);
 		}
 		/* skip external data directives */
 		else if (strstr(input, "x") == input)
@@ -1268,7 +1270,9 @@ int pre_flight_check(void)
 	/********************************************/
 	/* check for circular paths between hosts   */
 	/********************************************/
-	pre_flight_circular_check(&warnings, &errors);
+	if(!allow_circular_dependencies) {
+		pre_flight_circular_check(&warnings, &errors);
+	}
 
 	/********************************************/
 	/* check global event handler commands...   */

--- a/src/naemon/defaults.h
+++ b/src/naemon/defaults.h
@@ -85,6 +85,7 @@
 #define UPDATE_CHECK_RETRY_INTERVAL_WOBBLE                      60*60*3  /* 3 hour wobble on top of base retry interval */
 
 #define DEFAULT_ALLOW_EMPTY_HOSTGROUP_ASSIGNMENT        2        /* Allow assigning to empty hostgroups by default, but warn about it */
+#define DEFAULT_ALLOW_CIRCULAR_DEPENDENCIES             0        /* Allow circular depdendencies */
 
 #define DEFAULT_HOST_PERFDATA_FILE_TEMPLATE "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
 #define DEFAULT_SERVICE_PERFDATA_FILE_TEMPLATE "[SERVICEPERFDATA]\t$TIMET$\t$HOSTNAME$\t$SERVICEDESC$\t$SERVICEEXECUTIONTIME$\t$SERVICELATENCY$\t$SERVICEOUTPUT$\t$SERVICEPERFDATA$"

--- a/src/naemon/globals.h
+++ b/src/naemon/globals.h
@@ -143,6 +143,7 @@ extern int debug_verbosity;
 extern unsigned long max_debug_file_size;
 
 extern int allow_empty_hostgroup_assignment;
+extern int allow_circular_dependencies;
 
 extern time_t last_program_stop;
 extern time_t event_start;

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -163,6 +163,7 @@ double high_host_flap_threshold = DEFAULT_HIGH_HOST_FLAP_THRESHOLD;
 char *use_timezone = NULL;
 
 int allow_empty_hostgroup_assignment = DEFAULT_ALLOW_EMPTY_HOSTGROUP_ASSIGNMENT;
+int allow_circular_dependencies = DEFAULT_ALLOW_CIRCULAR_DEPENDENCIES;
 
 static long long check_file_size(char *, unsigned long, struct rlimit);
 


### PR DESCRIPTION
This PR enables circular dependencies for naemon's host graph.
The feature is has been manually tested but all the consequences of enabling this are not known. So this must be considered experimental.
Some are know and propagation of the following will be disabled:
* Scheduling downtime
* Enabling notifications
* Disabling notifications