### PR TITLE
Revert "Merge pull request #73 in MONITOR/naemon from bugfix/fix_newl…

### DIFF
--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -186,13 +186,8 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 	struct check_output *check_output = nm_malloc(sizeof(struct check_output));
 	check_output = parse_output(buf, check_output);
 	*short_output = check_output->short_output;
+	*long_output = check_output->long_output;
 	*perf_data = check_output->perf_data;
-	if(escape_newlines_please == TRUE && check_output->long_output != NULL) {
-		*long_output = g_strescape(check_output->long_output, "");
-		free(check_output->long_output);
-	} else {
-		*long_output = check_output->long_output;
-	}
 	free(check_output);
 	strip(*short_output);
 	strip(*perf_data);

--- a/src/naemon/xrddefault.c
+++ b/src/naemon/xrddefault.c
@@ -157,6 +157,7 @@ int xrddefault_save_state_information(void)
 	/* save host state information */
 	for (temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		struct host *conf_host;
+		gchar *tmp_escaped_long_output = (temp_host->long_plugin_output == NULL) ? g_strdup("") : g_strescape(temp_host->long_plugin_output, "");
 		conf_host = get_premod_host(temp_host->id);
 		fprintf(fp, "host {\n");
 		fprintf(fp, "host_name=%s\n", temp_host->name);
@@ -177,7 +178,7 @@ int xrddefault_save_state_information(void)
 		fprintf(fp, "current_problem_id=%lu\n", temp_host->current_problem_id);
 		fprintf(fp, "last_problem_id=%lu\n", temp_host->last_problem_id);
 		fprintf(fp, "plugin_output=%s\n", (temp_host->plugin_output == NULL) ? "" : temp_host->plugin_output);
-		fprintf(fp, "long_plugin_output=%s\n", (temp_host->long_plugin_output == NULL) ? "" : temp_host->long_plugin_output);
+		fprintf(fp, "long_plugin_output=%s\n", tmp_escaped_long_output);
 		fprintf(fp, "performance_data=%s\n", (temp_host->perf_data == NULL) ? "" : temp_host->perf_data);
 		fprintf(fp, "last_check=%lu\n", temp_host->last_check);
 		fprintf(fp, "next_check=%lu\n", temp_host->next_check);
@@ -243,12 +244,14 @@ int xrddefault_save_state_information(void)
 		}
 
 		fprintf(fp, "}\n");
+		g_free(tmp_escaped_long_output);
 
 	}
 
 	/* save service state information */
 	for (temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 		struct service *conf_svc;
+		gchar *tmp_escaped_long_output = (temp_service->long_plugin_output == NULL) ? g_strdup("") : g_strescape(temp_service->long_plugin_output, "");
 		conf_svc = get_premod_service(temp_service->id);
 		fprintf(fp, "service {\n");
 		fprintf(fp, "host_name=%s\n", temp_service->host_name);
@@ -281,7 +284,7 @@ int xrddefault_save_state_information(void)
 		fprintf(fp, "last_time_unknown=%lu\n", temp_service->last_time_unknown);
 		fprintf(fp, "last_time_critical=%lu\n", temp_service->last_time_critical);
 		fprintf(fp, "plugin_output=%s\n", (temp_service->plugin_output == NULL) ? "" : temp_service->plugin_output);
-		fprintf(fp, "long_plugin_output=%s\n", (temp_service->long_plugin_output == NULL) ? "" : temp_service->long_plugin_output);
+		fprintf(fp, "long_plugin_output=%s\n", tmp_escaped_long_output);
 		fprintf(fp, "performance_data=%s\n", (temp_service->perf_data == NULL) ? "" : temp_service->perf_data);
 		fprintf(fp, "last_check=%lu\n", temp_service->last_check);
 		fprintf(fp, "next_check=%lu\n", temp_service->next_check);
@@ -337,6 +340,7 @@ int xrddefault_save_state_information(void)
 		}
 
 		fprintf(fp, "}\n");
+		g_free(tmp_escaped_long_output);
 	}
 
 	/* save contact state information */
@@ -1001,7 +1005,7 @@ int xrddefault_read_state_information(void)
 							temp_host->plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "long_plugin_output")) {
 							nm_free(temp_host->long_plugin_output);
-							temp_host->long_plugin_output = nm_strdup(val);
+							temp_host->long_plugin_output = g_strcompress(val);
 						} else if (!strcmp(var, "performance_data")) {
 							nm_free(temp_host->perf_data);
 							temp_host->perf_data = nm_strdup(val);
@@ -1282,7 +1286,7 @@ int xrddefault_read_state_information(void)
 							temp_service->plugin_output = nm_strdup(val);
 						} else if (!strcmp(var, "long_plugin_output")) {
 							nm_free(temp_service->long_plugin_output);
-							temp_service->long_plugin_output = nm_strdup(val);
+							temp_service->long_plugin_output = g_strcompress(val);
 						} else if (!strcmp(var, "performance_data")) {
 							nm_free(temp_service->perf_data);
 							temp_service->perf_data = nm_strdup(val);

--- a/tests/test-checks.c
+++ b/tests/test-checks.c
@@ -164,18 +164,6 @@ START_TEST(newline_only)
 }
 END_TEST
 
-START_TEST(multiple_line_output_newline_escaping)
-{
-	full_output = "TEST OK - ...\n"
-				  "Here's a second line of output and\n"
-				  "one more\n";
-	output = strdup(full_output);
-	parse_check_output(output, &short_output, &long_output, &perf_data, TRUE, FALSE);
-	ck_assert_str_eq("TEST OK - ...", short_output);
-	ck_assert_str_eq("Here's a second line of output and\\none more\\n", long_output);
-}
-END_TEST
-
 Suite*
 checks_suite(void)
 {
@@ -194,7 +182,6 @@ checks_suite(void)
 	tcase_add_test(tc_output, no_plugin_output_at_all);
 	tcase_add_test(tc_output, newline_only);
 	tcase_add_test(tc_output, empty_plugin_output);
-	tcase_add_test(tc_output, multiple_line_output_newline_escaping);
 	suite_add_tcase(s, tc_output);
 	return s;
 }

--- a/tests/test-retention.c
+++ b/tests/test-retention.c
@@ -71,7 +71,7 @@ void teardown (void) {
 START_TEST(retention_data_for_hosts_long_output)
 {
 
-	const char * long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
+	const char * long_output = "This is a long \n plugin output \n of some sort \n and such \n";
 
 	hst->long_plugin_output = strdup(long_output);
 
@@ -89,7 +89,7 @@ END_TEST
 START_TEST(retention_data_for_services_long_output)
 {
 
-	const char * long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
+	const char * long_output = "This is a long \n plugin output \n of some sort \n and such \n";
 
 	svc->long_plugin_output = strdup(long_output);
 


### PR DESCRIPTION
…ine_escaping to master"

After the merge of this patch other naemon modules started failing, such as Merlin.
We shouldn't adapt the naemon api after another module. But instead adapt
the module in question according to the api.

This reverts commit c722025af4e6d588cd9af784f340117703dcafc0, reversing
changes made to 9ac4d20155ac805bd26849915b21192f328e5bf0.

Signed-off-by: Robin Engström <robin.engstrom@op5.com>