### PR TITLE
Naemon starts SIGKILLing the wrong processes if the PID wrap-around

### DIFF
--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -428,16 +428,10 @@ static void reap_jobs(void)
 			cp->ret = status;
 			memcpy(&cp->ei->rusage, &ru, sizeof(ru));
 			reaped++;
-			if (cp->ei->state != ESTALE) {
-				/* We leave any grandchild processes alive, until
-				 * the timeout for this job has expired (at which point they
-				 * will be reaped by the scheduled kill_job() event) in order
-				 * to preserve compatibility with older configurations.
-				 * See https://github.com/naemon/naemon-core/issues/137 for more
-				 * information.
-				 */
+			if (cp->ei->state != ESTALE)
 				finish_job(cp, cp->ei->state);
-			}
+			destroy_event(cp->ei->timed_event);
+			destroy_job(cp);
 		} else if (!pid || (pid < 0 && errno == ECHILD)) {
 			reapable = 0;
 		}

--- a/tests/test-worker.c
+++ b/tests/test-worker.c
@@ -201,7 +201,7 @@ START_TEST(worker_test_output_stdout_and_timeout)
 	run_worker_test(&j);
 }
 END_TEST
-
+/*
 START_TEST(worker_test_child_remains_to_cause_sideeffects)
 {
 	char filepath[] = "/tmp/XXXXX-naemon-worker-test";
@@ -225,7 +225,7 @@ START_TEST(worker_test_child_remains_to_cause_sideeffects)
 	unlink(filepath);
 }
 END_TEST
-
+*/
 
 
 /*
@@ -325,7 +325,7 @@ Suite *worker_suite(void)
 	tcase_add_test(tc_worker_output, worker_test_timeout);
 	tcase_add_test(tc_worker_output, worker_test_no_timeout_log);
 	tcase_add_test(tc_worker_output, worker_test_output_stdout_and_timeout);
-	tcase_add_test(tc_worker_output, worker_test_child_remains_to_cause_sideeffects);
+	//tcase_add_test(tc_worker_output, worker_test_child_remains_to_cause_sideeffects);
 	suite_add_tcase(s, tc_worker_output);
 
 	tc_command_worker = tcase_create("command worker tests");


### PR DESCRIPTION
This reverts commit 615ca32791cf2438458ecce8899faa0b5ad69274.

MON-10495
Naemon starts SIGKILLing the wrong processes if the PID wrap-around is too short.

This bug is a regression caused by fix of MON-8090.