### PR TITLE
fix memory leak when collecting performance data

### DIFF
--- a/src/naemon/perfdata.c
+++ b/src/naemon/perfdata.c
@@ -483,6 +483,9 @@ static int xpddefault_update_service_performance_data_file(nagios_macros *mac, s
 	if (svc == NULL)
 		return ERROR;
 
+	if (service_perfdata_fd < 0)
+		return OK;
+
 	if (service_perfdata_file_template == NULL)
 		return OK;
 
@@ -517,6 +520,9 @@ static int xpddefault_update_host_performance_data_file(nagios_macros *mac, host
 
 	if (hst == NULL)
 		return ERROR;
+
+	if (host_perfdata_fd < 0)
+		return OK;
 
 	if (host_perfdata_file_template == NULL)
 		return OK;


### PR DESCRIPTION
We need to check the service_perfdata_fd/host_perfdata_fd as well when pushing
performance data onto our buffer. Checking the template does not work because
it is never NULL as it will be set to a default if its unset.

This should fix issue #200.