### PR TITLE
Naemon starts SIGKILLing the wrong processes if the PID wrap-around is too short

### DIFF
--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -249,23 +249,27 @@ static int get_process_parent_id(const pid_t pid, pid_t * ppid) {
 
         sprintf(buffer, "/proc/%d/stat", pid);
         fp = fopen(buffer, "r");
-        if (!fp)
+        if (!fp) {
                 return errno;
+        }
 
         fread(buffer, sizeof (char), sizeof (buffer), fp);
         errreading = ferror(fp);
-        if (fclose(fp) != 0)
+        if (fclose(fp) != 0) {
                 return errno;
+        }
 
-        if (errreading != 0)
+        if (errreading != 0) {
                 return errreading;
+        }
 
         strtok(buffer, " "); // (1) pid  %d
         strtok(NULL, " "); // (2) comm  %s
         strtok(NULL, " "); // (3) state  %c
 
-        if ( (s_ppid = strtok(NULL, " ")) == NULL) // (4) ppid  %d
+        if ( (s_ppid = strtok(NULL, " ")) == NULL) {// (4) ppid  %d
                 return EBADF;
+        }
 
         *ppid = atoi(s_ppid);
         return 0;

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -244,7 +244,7 @@ static int finish_job(child_process *cp, int reason)
  */
 static int get_process_parent_id(const pid_t pid, pid_t * ppid) {
         char buffer[BUFSIZ], *s_ppid;
-        int errreading;
+        int errreading, size;
         FILE *fp;
 
         sprintf(buffer, "/proc/%d/stat", pid);
@@ -253,7 +253,7 @@ static int get_process_parent_id(const pid_t pid, pid_t * ppid) {
                 return errno;
         }
 
-        fread(buffer, sizeof (char), sizeof (buffer), fp);
+        size = fread(buffer, sizeof (char), sizeof (buffer), fp);
         errreading = ferror(fp);
         if (fclose(fp) != 0) {
                 return errno;

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -253,7 +253,10 @@ static int get_process_parent_id(const pid_t pid, pid_t * ppid) {
                 return errno;
         }
 
-        size = fread(buffer, sizeof (char), sizeof (buffer), fp);
+        size = fread(buffer, sizeof (char), sizeof (buffer) - 1, fp);
+        if (size > 0) {
+                buffer[size] = '\0';
+        }
         errreading = ferror(fp);
         if (fclose(fp) != 0) {
                 return errno;

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -291,7 +291,7 @@ static void kill_job(struct nm_event_execution_properties *event)
 	/* check if the child we'r killing belongs to this worker process */
 	wpid = getpid();
 	get_process_parent_id(pid, &ppid);
-	if (-1 != ppid && ppid != wpid) {
+	if (ppid == -1 || ppid != wpid) {
 		/* the pid might be reallocated but still exists in child proc list */
 		destroy_job(cp);
 		return;


### PR DESCRIPTION


MON-10495
Naemon starts SIGKILLing the wrong processes if the PID wrap-around is too short