### PR TITLE
Perform nudging to reschedule at 1 second next interval

### DIFF
--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -144,12 +144,8 @@ static void handle_service_check_event(struct nm_event_execution_properties *evp
 					nm_log(NSLOG_RUNTIME_WARNING,
 					       "\tMax concurrent service checks (%d) has been reached.  Nudging %s:%s by %d seconds...\n", max_parallel_service_checks, temp_service->host_name, temp_service->description, nudge_seconds);
 				} 
-				/* Simply reschedule at retry_interval instead, if defined (otherwise keep scheduling at next 1 second) */
-				if (temp_service->retry_interval != 0.0) {
-					schedule_next_service_check(temp_service, get_service_retry_interval_s(temp_service), 0);
-				} else {
-					schedule_next_service_check(temp_service, nudge_seconds, 0);
-				}
+				/* Simply reschedule at next 1 second */
+				schedule_next_service_check(temp_service, nudge_seconds, 0);
 				return;
 			} else {
 				if (nudging_in_progress == 1) { /* Print the last log when it has been recovered */

--- a/src/naemon/objects_service.c
+++ b/src/naemon/objects_service.c
@@ -13,6 +13,7 @@
 #include "lib/libnaemon.h"
 
 static GHashTable *service_hash_table;
+int nudging_in_progress = 0;
 service *service_list = NULL;
 service **service_ary = NULL;
 

--- a/src/naemon/objects_service.h
+++ b/src/naemon/objects_service.h
@@ -19,6 +19,7 @@ typedef struct service service;
 struct servicemember;
 typedef struct servicesmember servicesmember;
 
+extern int nudging_in_progress;
 extern struct service *service_list;
 extern struct service **service_ary;
 


### PR DESCRIPTION
When the max_concurrent_checks is set, currently the naemon just simply drops the check and reschedules it to next interval when the retry_interval is not defined (src/naemon/checks_service.c:145)

As a result, if the next interval is 1 minute, the next check will be scheduled to next 1 minute slot, causing the system to be idling for at most 1 minute.

If we have 200 service checks, then the delay will be very long, up to 200 minutes. With this, critical service check will not be able to run immediately when the system is back to idle and has to lose 1 minute interval

So, we propose to make use of "nudge_seconds" variable to perform reschedule in one second interval attempt.

Easy test would be to create 200 service checks and set max_concurrent_checks to 1 second. With max_concurrent_checks 1 second, the 200 service checks has to be able to run 200 checks in serial mode without making the system idle for 1 minute during that serial execution
