### PR TITLE
do not escape double quotes

### DIFF
--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -188,7 +188,7 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 	*short_output = check_output->short_output;
 	*perf_data = check_output->perf_data;
 	if(escape_newlines_please == TRUE && check_output->long_output != NULL) {
-		*long_output = g_strescape(check_output->long_output, "");
+		*long_output = g_strescape(check_output->long_output, "\"");
 		free(check_output->long_output);
 	} else {
 		*long_output = check_output->long_output;

--- a/tests/test-checks.c
+++ b/tests/test-checks.c
@@ -168,11 +168,11 @@ START_TEST(multiple_line_output_newline_escaping)
 {
 	full_output = "TEST OK - ...\n"
 				  "Here's a second line of output and\n"
-				  "one more\n";
+				  "one \"more\"\n";
 	output = strdup(full_output);
 	parse_check_output(output, &short_output, &long_output, &perf_data, TRUE, FALSE);
 	ck_assert_str_eq("TEST OK - ...", short_output);
-	ck_assert_str_eq("Here's a second line of output and\\none more\\n", long_output);
+	ck_assert_str_eq("Here's a second line of output and\\none \"more\"\\n", long_output);
 }
 END_TEST
 


### PR DESCRIPTION
they would end up escaped in the pluginoutput and break html output for example.

Signed-off-by: Sven Nierlein <sven@nierlein.de>