### PR TITLE
Allow compilation with GCC 7

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -199,6 +199,7 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 				set_state(STATE_INSQ | STATE_INARG);
 				continue;
 			}
+			/* FALLTHROUGH */
 		case '"':
 			if (have_state(STATE_INSQ))
 				break;

--- a/lib/snprintf.c
+++ b/lib/snprintf.c
@@ -493,6 +493,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				break;
 			case 'X':
 				cnk->flags |= DP_F_UP;
+				/* FALLTHROUGH */
 			case 'x':
 				cnk->type = CNK_HEX;
 				cnk->flags |= DP_F_UNSIGNED;
@@ -503,6 +504,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 			case 'G':
 			case 'F':
 				cnk->flags |= DP_F_UP;
+				/* FALLTHROUGH */
 			case 'a':
 				/* hex float not supported yet */
 			case 'e':

--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -1518,6 +1518,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		/***************/
 	case MACRO_HOSTGROUPNAMES:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_HOSTNAME:
 	case MACRO_HOSTALIAS:
 	case MACRO_HOSTADDRESS:
@@ -1612,6 +1613,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		/********************/
 	case MACRO_HOSTGROUPMEMBERS:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_HOSTGROUPNAME:
 	case MACRO_HOSTGROUPALIAS:
 	case MACRO_HOSTGROUPNOTES:
@@ -1640,6 +1642,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		/******************/
 	case MACRO_SERVICEGROUPNAMES:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_SERVICEDESC:
 	case MACRO_SERVICESTATE:
 	case MACRO_SERVICESTATEID:
@@ -1757,6 +1760,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 	case MACRO_SERVICEGROUPNOTESURL:
 	case MACRO_SERVICEGROUPACTIONURL:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_SERVICEGROUPNAME:
 	case MACRO_SERVICEGROUPALIAS:
 		/* a standard servicegroup macro */
@@ -1781,6 +1785,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		/******************/
 	case MACRO_CONTACTGROUPNAMES:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_CONTACTNAME:
 	case MACRO_CONTACTALIAS:
 	case MACRO_CONTACTEMAIL:
@@ -1841,6 +1846,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		/***********************/
 	case MACRO_CONTACTGROUPMEMBERS:
 		*free_macro = TRUE;
+		/* FALLTHROUGH */
 	case MACRO_CONTACTGROUPNAME:
 	case MACRO_CONTACTGROUPALIAS:
 		/* a standard contactgroup macro */


### PR DESCRIPTION
GCC 7 introduced new warnings which, as we compile Naemon with -Werror, meant that the builds failed.

The warnings are trigged when building naemon are:

-Wimplicit-fallthrough which warns if there are any fallthroughs in switch/case statements.

-Wformat-truncation which warns if output from a formatting operating could be truncated (for example when running snprintf)

These two patches ensures that Naemon can be correctly built with GCC 7. See the individual commit messages for further information.

This should fix #184 