### PR TITLE
Double naemon process

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -96,7 +96,9 @@ stop() {
     elif type start-stop-daemon >/dev/null 2>&1; then
         start-stop-daemon --stop --name ${prog} --pidfile ${pidfile} --exec ${exec}
     else
-        killproc -p ${pidfile} ${exec}
+        # keeping the pidfile as we are not sure if some other process owns this pidfile and the killproc will remove the copy of pidfile
+        cp ${pidfile} ${pidfile}.cp
+        killproc -p ${pidfile}.cp ${exec}
     fi
     retval=$?
     echo

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -748,9 +748,6 @@ int main(int argc, char **argv)
 
 	shutdown_command_file_worker();
 
-	if (daemon_mode == TRUE)
-		unlink(lock_file);
-
 	/* free misc memory */
 	nm_free(lock_file);
 	nm_free(config_file);


### PR DESCRIPTION
Double naemon process situtation is created if other process is monitoring naemon process and try to restart it.
Naemon relies on the pid file locking to ensure other instance of naemon could not be started. But the advisory locking breaks if the
pid file is remove. Bascially you can always create a new naemon process if you just remove the pidfile.
In the commit, the pidfile is not removed after naemon process exiting the main function and the modified the stop function in the
init.d file so that the pidfile is not removed after killing the naemon process.

Signed-off-by: Nian Tang <ntang@op5.com>