### PR TITLE
bump version in spec and debian files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+naemon-core (1.0.7) UNRELEASED; urgency=low
+
+  * new upstream release
+
+ -- Naemon Development Team <naemon-dev@monitoring-lists.org>  Fri, 08 Jun 2018 14:36:35 +0200
+
 naemon-core (1.0.6) UNRELEASED; urgency=low
 
   * new upstream release

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -9,7 +9,7 @@
 
 Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon-core
-Version: 1.0.6
+Version: 1.0.7
 Release: 0
 License: GPLv2
 Group: Applications/System
@@ -147,7 +147,9 @@ CFLAGS="%{mycflags}" LDFLAGS="$CFLAGS" %configure \
 %{__mkdir_p} -m 0755 %{buildroot}%{_localstatedir}/cache/naemon
 
 # Put the new RC sysconfig in place
-%if 0%{?suse_version} < 1315
+%if 0%{?suse_version} >= 1315
+sed -i daemon-systemd -e '/EnvironmentFile/d'
+%else
 %{__install} -d -m 0755 %{buildroot}/%{_sysconfdir}/sysconfig/
 %{__install} -m 0644 sample-config/naemon.sysconfig %{buildroot}/%{_sysconfdir}/sysconfig/naemon
 %endif


### PR DESCRIPTION
bump versions in the spec file and the debian changelog as well. Otherwise the release packages would have the old version. Only daily builds get increased automatically.