### PR TITLE
Fix reload command on el6 (fixes #239)

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -114,7 +114,7 @@ restart() {
 reload() {
     echo -n "Reloading $prog: "
     if [ -e $pidfile ]; then
-        PID=cat $pidfile;
+        PID=`cat $pidfile`;
         kill -HUP $PID >/dev/null 2>/dev/null
     else
         pkill -HUP -u ${user} -f ${exec}


### PR DESCRIPTION
The backticks are missing, otherwise it trys to execute the pidfile.

This fixes #239 