### PR TITLE
add obsoletes for naemon-tools

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -18,6 +18,7 @@ Packager: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
 Vendor: Naemon Core Development Team
 Source0: naemon-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
+Obsoletes: naemon-tools
 BuildRequires: gperf
 BuildRequires: logrotate
 BuildRequires: autoconf


### PR DESCRIPTION
naemon-tools are now part of the naemon-core project. Adding an obsoletes should
make updates smoother.

Signed-off-by: Sven Nierlein <sven@nierlein.de>