### PR TITLE
add missing newlines to log_debug_info (fixes #247)

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -51,7 +51,7 @@ void checks_init_hosts(void)
 
 	/******** SCHEDULE HOST CHECKS  ********/
 
-	log_debug_info(DEBUGL_EVENTS, 2, "Scheduling host checks...");
+	log_debug_info(DEBUGL_EVENTS, 2, "Scheduling host checks...\n");
 
 	/* add scheduled host checks to event queue */
 	for (temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -155,7 +155,7 @@ static void handle_host_check_event(struct nm_event_execution_properties *evprop
 			/* Somethings wrong, reschedule for retry interval instead, if retry_interval is specified. */
 			if (hst->retry_interval != 0.0) {
 				schedule_next_host_check(hst, get_host_retry_interval_s(hst), CHECK_OPTION_NONE);
-				log_debug_info(DEBUGL_CHECKS, 1, "Rescheduled next host check for %s", ctime(&hst->next_check));
+				log_debug_info(DEBUGL_CHECKS, 1, "Rescheduled next host check for %s\n", ctime(&hst->next_check));
 			}
 
 			/* update the status log */

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -49,7 +49,7 @@ void checks_init_services(void)
 {
 	service *temp_service = NULL;
 
-	log_debug_info(DEBUGL_EVENTS, 2, "Scheduling service checks...");
+	log_debug_info(DEBUGL_EVENTS, 2, "Scheduling service checks...\n");
 
 	/* add scheduled service checks to event queue */
 	for (temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -284,7 +284,7 @@ static int command_file_worker(int sd)
 			 * a bad thing because rotated logfiles then have overlapping timestamps
 			 * which breaks livestatus. So make this a debug log entry only.
 			 */
-			log_debug_info(DEBUGL_IPC, 1, "Command file worker: Naemon main process is dead (%m)");
+			log_debug_info(DEBUGL_IPC, 1, "Command file worker: Naemon main process is dead (%m)\n");
 			return EXIT_SUCCESS;
 		}
 

--- a/src/naemon/notifications.c
+++ b/src/naemon/notifications.c
@@ -132,7 +132,7 @@ static int update_notification_suppression_reason(enum NotificationSuppressionTy
 #define _log_nsr(S) if (enable_notification_suppression_reason_logging) { \
 	if (update_notification_suppression_reason(type, objid, reason)) { \
 		nm_log(log_level, "%s NOTIFICATION SUPPRESSED: %s;%s", type_name, objname, S); \
-	} else { log_debug_info(DEBUGL_NOTIFICATIONS, DEBUGV_BASIC, "%s NOTIFICATION SUPPRESSED: %s;%s", type_name, objname, S);}}
+	} else { log_debug_info(DEBUGL_NOTIFICATIONS, DEBUGV_BASIC, "%s NOTIFICATION SUPPRESSED: %s;%s\n", type_name, objname, S);}}
 void log_notification_suppression_reason(enum NotificationSuppressionReason reason,
 		enum NotificationSuppressionType type, void *primary_obj, void *secondary_obj, const char *extra_info)
 {
@@ -358,7 +358,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 	time(&current_time);
 	gettimeofday(&start_time, NULL);
 
-	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "** Service Notification Attempt ** Host: '%s', Service: '%s', Type: %s, Options: %d, Current State: %d, Last Notification: %s", svc->host_name, svc->description, notification_reason_name(type), options, svc->current_state, ctime(&svc->last_notification));
+	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "** Service Notification Attempt ** Host: '%s', Service: '%s', Type: %s, Options: %d, Current State: %d, Last Notification: %s\n", svc->host_name, svc->description, notification_reason_name(type), options, svc->current_state, ctime(&svc->last_notification));
 
 
 	/* check the viability of sending out a service notification */
@@ -532,7 +532,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 				/* calculate the next acceptable re-notification time */
 				svc->next_notification = get_next_service_notification_time(svc, current_time);
 
-				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.  Next possible notification time: %s", contacts_notified, ctime(&svc->next_notification));
+				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.  Next possible notification time: %s\n", contacts_notified, ctime(&svc->next_notification));
 
 				/* update the last notification time for this service (this is needed for rescheduling later notifications) */
 				svc->last_notification = current_time;
@@ -547,7 +547,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 				/* adjust current notification number */
 				svc->current_notification_number--;
 
-				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s", ctime(&svc->next_notification));
+				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s\n", ctime(&svc->next_notification));
 			}
 		}
 
@@ -817,7 +817,7 @@ int check_service_notification_viability(service *svc, int type, int options)
 	/* don't notify if we haven't waited long enough since the last time (and the service is not marked as being volatile) */
 	if ((current_time < svc->next_notification) && svc->is_volatile == FALSE) {
 		LOG_SERVICE_NSR(NSR_RE_NOT_YET);
-		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next valid notification time: %s", ctime(&svc->next_notification));
+		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next valid notification time: %s\n", ctime(&svc->next_notification));
 		return ERROR;
 	}
 
@@ -1244,7 +1244,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 	time(&current_time);
 	gettimeofday(&start_time, NULL);
 
-	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "** Host Notification Attempt ** Host: '%s', Type: %s, Options: %d, Current State: %d, Last Notification: %s", hst->name, notification_reason_name(type), options, hst->current_state, ctime(&hst->last_notification));
+	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "** Host Notification Attempt ** Host: '%s', Type: %s, Options: %d, Current State: %d, Last Notification: %s\n", hst->name, notification_reason_name(type), options, hst->current_state, ctime(&hst->last_notification));
 
 	/* check viability of sending out a host notification */
 	if (check_host_notification_viability(hst, type, options) == ERROR) {
@@ -1423,7 +1423,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 				/* update notifications flags */
 				add_notified_on(hst, hst->current_state);
 
-				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.  Next possible notification time: %s", contacts_notified, ctime(&hst->next_notification));
+				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.  Next possible notification time: %s\n", contacts_notified, ctime(&hst->next_notification));
 			}
 
 			/* we didn't end up notifying anyone */
@@ -1432,7 +1432,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 				/* adjust current notification number */
 				hst->current_notification_number--;
 
-				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s", ctime(&hst->next_notification));
+				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s\n", ctime(&hst->next_notification));
 			}
 		}
 
@@ -1679,7 +1679,7 @@ int check_host_notification_viability(host *hst, int type, int options)
 	/* check if its time to re-notify the contacts about the host... */
 	if (current_time < hst->next_notification) {
 		LOG_HOST_NSR(NSR_RE_NOT_YET);
-		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next acceptable notification time: %s", ctime(&hst->next_notification));
+		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next acceptable notification time: %s\n", ctime(&hst->next_notification));
 		return ERROR;
 	}
 

--- a/src/naemon/perfdata.c
+++ b/src/naemon/perfdata.c
@@ -490,14 +490,14 @@ static int xpddefault_update_service_performance_data_file(nagios_macros *mac, s
 		return OK;
 
 	nm_asprintf(&raw_output, "%s\n", service_perfdata_file_template);
-	log_debug_info(DEBUGL_PERFDATA, 2, "Raw service performance data file output: %s", raw_output);
+	log_debug_info(DEBUGL_PERFDATA, 2, "Raw service performance data file output: %s\n", raw_output);
 
 	/* process any macros in the raw output */
 	process_macros_r(mac, raw_output, &processed_output, 0);
 	if (processed_output == NULL)
 		return ERROR;
 
-	log_debug_info(DEBUGL_PERFDATA, 2, "Processed service performance data file output: %s", processed_output);
+	log_debug_info(DEBUGL_PERFDATA, 2, "Processed service performance data file output: %s\n", processed_output);
 
 	nm_bufferqueue_push(service_perfdata_bq, processed_output, strlen(processed_output));
 	/* temporary failures are fine - if it's serious, we log before we run the processing event */
@@ -528,14 +528,14 @@ static int xpddefault_update_host_performance_data_file(nagios_macros *mac, host
 		return OK;
 
 	nm_asprintf(&raw_output, "%s\n", host_perfdata_file_template);
-	log_debug_info(DEBUGL_PERFDATA, 2, "Raw host performance file output: %s", raw_output);
+	log_debug_info(DEBUGL_PERFDATA, 2, "Raw host performance file output: %s\n", raw_output);
 
 	/* process any macros in the raw output */
 	process_macros_r(mac, raw_output, &processed_output, 0);
 	if (processed_output == NULL)
 		return ERROR;
 
-	log_debug_info(DEBUGL_PERFDATA, 2, "Processed host performance data file output: %s", processed_output);
+	log_debug_info(DEBUGL_PERFDATA, 2, "Processed host performance data file output: %s\n", processed_output);
 
 	nm_bufferqueue_push(host_perfdata_bq, processed_output, strlen(processed_output));
 	/* temporary failures are fine - if it's serious, we log before we run the processing event */

--- a/src/naemon/workers.c
+++ b/src/naemon/workers.c
@@ -119,7 +119,7 @@ static struct wproc_list *get_wproc_list(const char *cmd)
 		wp_list = g_hash_table_lookup(specialized_workers, ++slash);
 	}
 	if (wp_list != NULL) {
-		log_debug_info(DEBUGL_CHECKS, 1, "Found specialized worker(s) for '%s'", (slash && *slash != '/') ? slash : cmd_name);
+		log_debug_info(DEBUGL_CHECKS, 1, "Found specialized worker(s) for '%s'\n", (slash && *slash != '/') ? slash : cmd_name);
 	}
 	if (cmd_name)
 		free(cmd_name);
@@ -504,7 +504,7 @@ static int handle_worker_result(int sd, int events, void *arg)
 			         tv_delta_f(&wpres.start, &wpres.stop));
 		}
 		if (error_reason) {
-			log_debug_info(DEBUGL_IPC, DEBUGV_BASIC, "wproc: job %d from worker %s %s",
+			log_debug_info(DEBUGL_IPC, DEBUGV_BASIC, "wproc: job %d from worker %s %s\n",
 					job->id, wp->name, error_reason);
 			log_debug_info(DEBUGL_IPC, DEBUGV_MORE, "wproc:   command: %s\n", job->command);
 			log_debug_info(DEBUGL_IPC, DEBUGV_MORE, "wproc:   early_timeout=%d; exited_ok=%d; wait_status=%d; error_code=%d;\n",


### PR DESCRIPTION
newlines are not automatically added and must be manually appended to each log entry.

Signed-off-by: Sven Nierlein <sven@nierlein.de>