### PR TITLE
Make naemon-core depend on libnaemon

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -49,6 +49,7 @@ Requires(pre): shadow-utils
 %endif
 %endif
 Requires:  logrotate
+Requires:  libnaemon >= %{version}
 
 %description
 Naemon is an application, system and network monitoring application.


### PR DESCRIPTION
Resolves upgrade issues when updating from 1.0.6 to 1.0.8.

Upgrading from Naemon 1.0.6 / 1.0.7 on CentOS 7 may, depending on the order yum decides to install packages, fail with:

`file /usr/share/man/man8/naemonstats.8 from install of naemon-core-1.0.8-0.x86_64 conflicts with file from package libnaemon-1.0.6-1.el7.centos.x86_64`

This lets naemon-core depend on libnaemon, ensuring updating always takes place in the correct order.

Fixes #249.