### PR TITLE
No on-demand host check on service hard critical

### DIFF
--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -754,7 +754,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 				log_debug_info(DEBUGL_CHECKS, 1, "* Using cached host state: %d\n", temp_host->current_state);
 				update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
 				update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
-			} else {
+			} else if (state_change || temp_service->state_type == SOFT_STATE) {
 				schedule_next_host_check(temp_host, 0, CHECK_OPTION_DEPENDENCY_CHECK);
 			}
 		}
@@ -764,7 +764,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 			log_debug_info(DEBUGL_CHECKS, 1, "Host is currently %s.\n", host_state_name(temp_host->current_state));
 
-			if (execute_host_checks) {
+			if (execute_host_checks && (state_change || temp_service->state_type == SOFT_STATE)) {
 				schedule_host_check(temp_host, current_time, CHECK_OPTION_NONE);
 			}
 			/* else fake the host check, but (possibly) resend host notifications to contacts... */


### PR DESCRIPTION
The current [Naemon documentation](https://www.naemon.org/documentation/usersguide/hostchecks.html#when_are_host_checks_performed) states that on-demand host checks are performed when a service associated with the host changes state. This is not actually what happens. Currently on-demand host checks are scheduled on any service checks which results in a non-ok state for the service (even if there is no state change)

This commit changes that logic slightly, so that on-demand host checks are performed when the service changes state OR if the service is in a soft state. That is, we no longer do on-demand host checks on non-ok service checks, if the service is already in hard critical.

This ensures that we do not do a high amount of host checks when a host and all its services are in hard critical. For example, assume that we have a host with 20 services, and that the host and services have the same check_interval. In the situation were both the host and services are in hard critical, we would now do at least 20 host checks in every check_interval period. One host check for every service check. With this change we only schedule as host check if the service recovers again.

The time for a host to recover from an outage, can be slightly longer now if services goes up at a later time than the host itself. This could happen on a server reboot/startup as the host check(ping) might be responding marginally quicker than some of the services that are being checked.

We still do many on-demand host checks, that should ensure that the host goes into hard critical before the services, thus avoiding notification storms. This is true unless the max_attemps for the host is significantly higher than its services (and the host has few services).

More context here: https://jira.op5.com/browse/MON-5625