### PR TITLE
parse_check: Don't escape already escaped newlines

### DIFF
--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -188,7 +188,7 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 	*short_output = check_output->short_output;
 	*perf_data = check_output->perf_data;
 	if(escape_newlines_please == TRUE && check_output->long_output != NULL) {
-		*long_output = g_strescape(check_output->long_output, "\"");
+		*long_output = g_strescape(check_output->long_output, "\",\\n");
 		free(check_output->long_output);
 	} else {
 		*long_output = check_output->long_output;

--- a/tests/test-checks.c
+++ b/tests/test-checks.c
@@ -176,6 +176,19 @@ START_TEST(multiple_line_output_newline_escaping)
 }
 END_TEST
 
+/* Ensure that we do not double escape newlines in long_plugin_output */
+START_TEST(multiple_line_output_double_newline_escaping)
+{
+	full_output = "TEST OK - ...\n"
+				  "Here's a second line of output and\\n"
+				  "one \"more\"\\n";
+	output = strdup(full_output);
+	parse_check_output(output, &short_output, &long_output, &perf_data, TRUE, FALSE);
+	ck_assert_str_eq("TEST OK - ...", short_output);
+	ck_assert_str_eq("Here's a second line of output and\\none \"more\"\\n", long_output);
+}
+END_TEST
+
 Suite*
 checks_suite(void)
 {
@@ -195,6 +208,7 @@ checks_suite(void)
 	tcase_add_test(tc_output, newline_only);
 	tcase_add_test(tc_output, empty_plugin_output);
 	tcase_add_test(tc_output, multiple_line_output_newline_escaping);
+	tcase_add_test(tc_output, multiple_line_output_double_newline_escaping);
 	suite_add_tcase(s, tc_output);
 	return s;
 }


### PR DESCRIPTION
This patch ensures that newlines which are already escaped in a check results long_output is not escaped again.

When running [Merlin](https://github.com/op5/merlin) to have a distributed Naemon setup, we had a problem where a check result coming from another node, would have double escaped new lines. Merlin sends check results to different nodes, after the check_result has been parsed. The receiving node would in turn also run it through Naemons check result parsing mechanism. This resulted in newlines being escaped twice, once on the remote node, and once on the master (for example). 

This fix works by adding "\\n" to the exception list of g_strescape, which means already escaped newlines won't be escaped again.

This fixes [MON-11112](https://jira.op5.com/browse/MON-11112)