### PR TITLE
Init: Increase delay between SIGTERM and SIGKILL

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -96,9 +96,11 @@ start() {
 stop() {
     echo -n "Stopping $prog: "
     if [ "x${is_suse}" == "xyes" ]; then
-        killproc -p ${pidfile} -t 10 $exec
+        killproc -p ${pidfile} -t 90 $exec
     elif type start-stop-daemon >/dev/null 2>&1; then
         start-stop-daemon --stop --name ${prog} --pidfile ${pidfile} --exec ${exec}
+    elif [ -e /etc/redhat-release ]; then
+        killproc -p ${pidfile} -d 90 ${exec}
     else
         killproc -p ${pidfile} ${exec}
     fi

--- a/features/daemonize.feature
+++ b/features/daemonize.feature
@@ -23,9 +23,3 @@ Feature: Daemonization
     Scenario: Naemon successfully daemonizes when a valid config is provided
         Given config verification pass
         Then naemon should successfully start
-
-    Scenario: Naemon fails to daemonize when an invalid
-        host_notification_commands argument is provided in a contact config
-        Given I have an invalid naemon contact configuration
-        And config verification fail
-        Then naemon should output a sensible error message

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -1,0 +1,15 @@
+Feature: Logging
+	Checks that various log messages are printed correctly
+
+    Scenario: Naemon fails to daemonize when an invalid
+        host_notification_commands argument is provided in a contact config
+        Given I have an invalid naemon contact configuration
+        And config verification fail
+        Then naemon should output a sensible error message
+
+    Scenario: Output retention data log message when stopped
+        Given I start naemon
+        When I stop naemon
+        And I wait for 5 seconds
+        Then naemon should not be running
+        And naemon should output a retention data saved log message

--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -96,6 +96,20 @@ def naemon_restart(context):
         pass
 
 
+@when('I stop naemon')
+def naemon_stop(context):
+    assert os.path.exists('./naemon.pid'), (
+        'Naemon pid file was not found'
+    )
+    pid = int(open('./naemon.pid').read())
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print ('Sent SIGTERM to naemon process (%i)' % pid)
+    except OSError as e:
+        print (os.strerror(e.errno))
+        pass
+
+
 @then('naemon should fail to start')
 def naemon_start_fail(context):
     context.execute_steps(u'When I start naemon')
@@ -128,10 +142,22 @@ def naemon_is_running(context):
     )
 
 
+@then('naemon should not be running')
+def naemon_is_not_running(context):
+    assert not os.path.exists('./naemon.pid'), (
+        'Naemon is running'
+    )
+
+
 @then('naemon should output a sensible error message')
 def naemon_error_msg(context):
     context.execute_steps(u'When I start naemon')
     assert 'Error: Host notification command' in open('naemon.log').read()
+
+
+@then('naemon should output a retention data saved log message')
+def naemon_retention_msg(context):
+    assert 'Retention data successfully saved.' in open('naemon.log').read()
 
 
 @when('I wait for (?P<seconds>[0-9]+) seconds?')

--- a/src/naemon/sretention.c
+++ b/src/naemon/sretention.c
@@ -26,7 +26,7 @@ void save_state_information_eventhandler(struct nm_event_execution_properties *e
 	if(evprop->execution_type == EVENT_EXEC_NORMAL) {
 		schedule_event(retention_update_interval * interval_length, save_state_information_eventhandler, evprop->user_data);
 
-		status = save_state_information(FALSE);
+		status = save_state_information(TRUE);
 
 		if(status == OK) {
 			nm_log(NSLOG_PROCESS_INFO,
@@ -88,6 +88,10 @@ int save_state_information(int autosave)
 
 	if (result == ERROR)
 		return ERROR;
+
+	if (!autosave) {
+		nm_log(NSLOG_INFO_MESSAGE, "Retention data successfully saved.");
+	}
 
 	return OK;
 }


### PR DESCRIPTION
When using killproc to kill a process, first a SIGTERM signal is sent, and after a default of 3 seconds (5 seconds on SUSE), a SIGKILL is sent.
    
On larger setups we often see that 3 seconds, is not sufficient for Naemon to shutdown, and as a result retention data might not be correctly saved.
    
This commit increase the timeout to 90 seconds on redhat based releases and on SUSE. We only change this one these systems, as killproc seems to differ between different distributions, and might not offer the same arguments. 90 seconds timeout is the default for systemd, and the therefore the rational for choosing that value.

In addition added a log message on save of retention data at shutdown to aid debugging.

More context: [MON-10565](https://jira.op5.com/browse/MON-10565).