### PR TITLE
el6: use correct logrotate script

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -170,6 +170,11 @@ mkdir -p -m 0755 %{buildroot}%{_localstatedir}/run/naemon
 %{__mv} -f %{buildroot}%{_initrddir}/naemon %{buildroot}/%{_bindir}/naemon-ctl
 %endif
 
+%if 0%{?el6}
+%{__rm} %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+%{__install} -m 0644 naemon.logrotate.el6 %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
+%endif
+
 %clean
 %{__rm} -rf %{buildroot}
 


### PR DESCRIPTION
Since we install the el7 logrotate in our Makefile.am without further OS
detection we need to replace the logrotate file for el6 later. Otherwise we
would end up with the el7 file and no logrotation.