### PR TITLE
Always schedule next_check within check_interval

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -65,10 +65,13 @@ void checks_init_hosts(void)
  		 * If use_retained_scheduling_info is enabled, we use the previously set
  		 * next_check. If the check was missed, schedule it within the next
  		 * interval length. If more than one check was missed, we schedule the check
- 		 * randomly instead.
+ 		 * randomly instead. If the next_check is more than one check_interval in
+ 		 * the future, we also schedule the next check randomly. This indicates
+ 		 * that the check_interval has been lowered over restarts.
  		 */
 		if (use_retained_scheduling_info == TRUE &&
-		    temp_host->next_check > current_time-get_host_check_interval_s(temp_host)) {
+		    temp_host->next_check > current_time-get_host_check_interval_s(temp_host) &&
+		    temp_host->next_check <= current_time+get_host_check_interval_s(temp_host)) {
 			if (temp_host->next_check < current_time) {
 				delay = ranged_urand(0, interval_length);
 			} else {

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -63,10 +63,13 @@ void checks_init_services(void)
  		 * If use_retained_scheduling_info is enabled, we use the previously set
  		 * next_check. If the check was missed, schedule it within the next
  		 * interval length. If more than one check was missed, we schedule the check
- 		 * randomly instead.
+ 		 * randomly instead. If the next_check is more than one check_interval in
+ 		 * the future, we also schedule the next check randomly. This indicates
+ 		 * that the check_interval has been lowered over restarts.
  		 */
 		if (use_retained_scheduling_info == TRUE &&
-		    temp_service->next_check > current_time-get_service_check_interval_s(temp_service)) {
+		    temp_service->next_check > current_time-get_service_check_interval_s(temp_service) &&
+		    temp_service->next_check <= current_time+get_service_check_interval_s(temp_service)) {
 			if (temp_service->next_check < current_time) {
 				delay = ranged_urand(0, interval_length);
 			} else {


### PR DESCRIPTION
After https://github.com/naemon/naemon-core/pull/259 we now keep the
next_check schedule over restarts if use_retained_schedule_info is
enabled. However after this patch, if one would lower the check_interval
it was possible that after the restart, the next check of an object
would be more than one check_interval away.

This commit ensures that if the next_check is more than one
check_interval away, then we randomly schedule the next check, instead
of using the retention data.

This fixed MON-11295 (https://jira.op5.com/browse/MON-11295)

Signed-off-by: Jacob Hansen <jhansen@op5.com>