### PR TITLE
reset is_executing flag when processing active host check result (fix…

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -431,6 +431,8 @@ int update_host_state_post_check(struct host *hst, struct check_result *cr)
 
 	/* adjust return code (active checks only) */
 	if (cr->check_type == CHECK_TYPE_ACTIVE) {
+		hst->is_executing = FALSE;
+
 		if (cr->early_timeout) {
 			nm_free(hst->plugin_output);
 			nm_free(hst->long_plugin_output);


### PR DESCRIPTION
…es #154)

right now, we have to reset the flag in mod-gearman but hosts should just
behave like services here when processing check results and reset the flag on
processing an active check result.

Signed-off-by: Sven Nierlein <sven@nierlein.de>