### PR TITLE
fix memory leak when overriding checks

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -318,6 +318,7 @@ static int run_async_host_check(host *hst, int check_options, double latency)
 	if (neb_result == NEBERROR_CALLBACKOVERRIDE) {
 		clear_volatile_macros_r(&mac);
 		free_check_result(cr);
+		nm_free(cr);
 		nm_free(processed_command);
 		return OK;
 	}
@@ -645,7 +646,7 @@ static void handle_worker_host_check(wproc_result *wpres, void *arg, int flags)
 		process_check_result(cr);
 	}
 	free_check_result(cr);
-	free(cr);
+	nm_free(cr);
 }
 
 static gboolean propagate_when_not_up(gpointer _name, gpointer _hst, gpointer user_data)

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -307,6 +307,7 @@ static int run_scheduled_service_check(service *svc, int check_options, double l
 	if (neb_result == NEBERROR_CALLBACKOVERRIDE) {
 		clear_volatile_macros_r(&mac);
 		free_check_result(cr);
+		nm_free(cr);
 		nm_free(processed_command);
 		return OK;
 	}
@@ -365,7 +366,7 @@ static void handle_worker_service_check(wproc_result *wpres, void *arg, int flag
 		process_check_result(cr);
 	}
 	free_check_result(cr);
-	free(cr);
+	nm_free(cr);
 }
 
 


### PR DESCRIPTION
Overriding checks during the host/service_initiate stage leads to a memory leak.
Freeing the check_result pointer helps.