### PR TITLE
Introduce retained_scheduling_randomize_window

### DIFF
--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -468,6 +468,16 @@ use_retained_program_state=1
 use_retained_scheduling_info=1
 
 
+# RETAINED_SCHEDULING_RANDOMIZE_WINDOW
+# If use_retained_scheduling info is enabled, this setting
+# sets the window (in seconds), in which checks that were
+# supposed to executed during a restart, is rescheduled.
+# That is, if set to 60 seconds, then all checks that were
+# missed due to a restart will be scheduled randomly to be
+# executed in the first 60 seconds after a restart.
+
+retained_scheduling_randomize_windows=60
+
 
 # RETAINED ATTRIBUTE MASKS (ADVANCED FEATURE)
 # The following variables are used to specify specific host and

--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -479,7 +479,7 @@ use_retained_scheduling_info=1
 # the objects check_interval, the check_interval is used
 # instead.
 
-retained_scheduling_randomize_windows=60
+retained_scheduling_randomize_window=60
 
 
 # RETAINED ATTRIBUTE MASKS (ADVANCED FEATURE)

--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -475,6 +475,9 @@ use_retained_scheduling_info=1
 # That is, if set to 60 seconds, then all checks that were
 # missed due to a restart will be scheduled randomly to be
 # executed in the first 60 seconds after a restart.
+# If the retained_scheduling_randomize_window is larger than
+# the objects check_interval, the check_interval is used
+# instead.
 
 retained_scheduling_randomize_windows=60
 

--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -73,7 +73,11 @@ void checks_init_hosts(void)
 		    temp_host->next_check > current_time-get_host_check_interval_s(temp_host) &&
 		    temp_host->next_check <= current_time+get_host_check_interval_s(temp_host)) {
 			if (temp_host->next_check < current_time) {
-				delay = ranged_urand(0, retained_scheduling_randomize_window);
+				int scheduling_window = retained_scheduling_randomize_window;
+				if (retained_scheduling_randomize_window > get_host_check_interval_s(temp_host) ) {
+					scheduling_window = get_host_check_interval_s(temp_host);
+				}
+				delay = ranged_urand(0, scheduling_window);
 			} else {
 				delay = temp_host->next_check-current_time;
 			}

--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -64,7 +64,7 @@ void checks_init_hosts(void)
  		/* Determine the delay used for the first check event.
  		 * If use_retained_scheduling_info is enabled, we use the previously set
  		 * next_check. If the check was missed, schedule it within the next
- 		 * interval length. If more than one check was missed, we schedule the check
+ 		 * retained_scheduling_randomize_window. If more than one check was missed, we schedule the check
  		 * randomly instead. If the next_check is more than one check_interval in
  		 * the future, we also schedule the next check randomly. This indicates
  		 * that the check_interval has been lowered over restarts.
@@ -73,7 +73,7 @@ void checks_init_hosts(void)
 		    temp_host->next_check > current_time-get_host_check_interval_s(temp_host) &&
 		    temp_host->next_check <= current_time+get_host_check_interval_s(temp_host)) {
 			if (temp_host->next_check < current_time) {
-				delay = ranged_urand(0, interval_length);
+				delay = ranged_urand(0, retained_scheduling_randomize_window);
 			} else {
 				delay = temp_host->next_check-current_time;
 			}

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -62,7 +62,7 @@ void checks_init_services(void)
  		/* Determine the delay used for the first check event.
  		 * If use_retained_scheduling_info is enabled, we use the previously set
  		 * next_check. If the check was missed, schedule it within the next
- 		 * interval length. If more than one check was missed, we schedule the check
+ 		 * retained_scheduling_randomize_window. If more than one check was missed, we schedule the check
  		 * randomly instead. If the next_check is more than one check_interval in
  		 * the future, we also schedule the next check randomly. This indicates
  		 * that the check_interval has been lowered over restarts.
@@ -71,7 +71,7 @@ void checks_init_services(void)
 		    temp_service->next_check > current_time-get_service_check_interval_s(temp_service) &&
 		    temp_service->next_check <= current_time+get_service_check_interval_s(temp_service)) {
 			if (temp_service->next_check < current_time) {
-				delay = ranged_urand(0, interval_length);
+				delay = ranged_urand(0, retained_scheduling_randomize_window);
 			} else {
 				delay = temp_service->next_check-current_time;
 			}

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -71,7 +71,11 @@ void checks_init_services(void)
 		    temp_service->next_check > current_time-get_service_check_interval_s(temp_service) &&
 		    temp_service->next_check <= current_time+get_service_check_interval_s(temp_service)) {
 			if (temp_service->next_check < current_time) {
-				delay = ranged_urand(0, retained_scheduling_randomize_window);
+				int scheduling_window = retained_scheduling_randomize_window;
+				if (retained_scheduling_randomize_window > get_service_check_interval_s(temp_service)) {
+					scheduling_window = get_service_check_interval_s(temp_service);
+				}
+				delay = ranged_urand(0, scheduling_window);
 			} else {
 				delay = temp_service->next_check-current_time;
 			}

--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -410,6 +410,16 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			use_retained_scheduling_info = (atoi(value) > 0) ? TRUE : FALSE;
 		}
 
+		else if (!strcmp(variable, "retained_scheduling_randomize_window")) {
+
+			retained_scheduling_randomize_window = atoi(value);
+			if (retained_scheduling_randomize_window < 0) {
+				nm_asprintf(&error_message, "Illegal value for retained_scheduling_randomize_window");
+				error = TRUE;
+				break;
+			}
+		}
+
 		else if (!strcmp(variable, "retention_scheduling_horizon")) {
 
 			retention_scheduling_horizon = atoi(value);

--- a/src/naemon/defaults.h
+++ b/src/naemon/defaults.h
@@ -23,6 +23,7 @@
 #define DEFAULT_MAX_CHECK_RESULT_AGE				3600    /* maximum number of seconds that a check result file is considered to be valid */
 #define DEFAULT_MAX_PARALLEL_SERVICE_CHECKS 			0	/* maximum number of service checks we can have running at any given time (0=unlimited) */
 #define DEFAULT_RETENTION_UPDATE_INTERVAL			60	/* minutes between auto-save of retention data */
+#define DEFAULT_RETAINED_SCHEDULING_RANDOMIZE_WINDOW	60	/* number of seconds used for randomizing the re-scheduling of checks missed over a restart */
 #define DEFAULT_RETENTION_SCHEDULING_HORIZON    		900     /* max seconds between program restarts that we will preserve scheduling information */
 #define DEFAULT_STATUS_UPDATE_INTERVAL				60	/* seconds between aggregated status data updates */
 #define DEFAULT_FRESHNESS_CHECK_INTERVAL        		60      /* seconds between service result freshness checks */

--- a/src/naemon/globals.h
+++ b/src/naemon/globals.h
@@ -110,6 +110,7 @@ extern int retain_state_information;
 extern int retention_update_interval;
 extern int use_retained_program_state;
 extern int use_retained_scheduling_info;
+extern int retained_scheduling_randomize_window;
 extern int retention_scheduling_horizon;
 extern char *retention_file;
 extern unsigned long retained_host_attribute_mask;

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -112,6 +112,7 @@ int retain_state_information = FALSE;
 int retention_update_interval = DEFAULT_RETENTION_UPDATE_INTERVAL;
 int use_retained_program_state = TRUE;
 int use_retained_scheduling_info = FALSE;
+int retained_scheduling_randomize_window = DEFAULT_RETAINED_SCHEDULING_RANDOMIZE_WINDOW;
 int retention_scheduling_horizon = DEFAULT_RETENTION_SCHEDULING_HORIZON;
 char *retention_file = NULL;
 

--- a/tests/test-check-scheduling.c
+++ b/tests/test-check-scheduling.c
@@ -671,13 +671,13 @@ END_TEST
 
 /* If use_retained_scheduling_info is enabled, but we missed one check, due to a
  * restart then the next check should be scheduled within the next
- * interval_length period
+ * check_interval period
  */
 START_TEST(host_retain_missed_check)
 {
 	time_t current_time = time(NULL);
 	time_t next_check = current_time-60;
-	time_t expected_max_next_check = current_time+interval_length;
+	time_t expected_max_next_check;
 	use_retained_scheduling_info=TRUE;
 
 	hst->retry_interval = 1.0;
@@ -685,6 +685,7 @@ START_TEST(host_retain_missed_check)
 	hst->current_state = STATE_UP;
 	hst->state_type = HARD_STATE;
 	hst->next_check = next_check;
+	expected_max_next_check = current_time+retained_scheduling_randomize_window;
 
 	/* Simulates a restart */
 	checks_init_hosts();
@@ -802,7 +803,7 @@ START_TEST(service_retain_missed_check)
 {
 	time_t current_time = time(NULL);
 	time_t next_check = current_time-60;
-	time_t expected_max_next_check = current_time+interval_length;
+	time_t expected_max_next_check;
 	use_retained_scheduling_info=TRUE;
 
 	svc->retry_interval = 1.0;
@@ -810,6 +811,7 @@ START_TEST(service_retain_missed_check)
 	svc->current_state = STATE_UP;
 	svc->state_type = HARD_STATE;
 	svc->next_check = next_check;
+	expected_max_next_check = current_time+retained_scheduling_randomize_window;
 
 	/* Simulates a restart */
 	checks_init_services();


### PR DESCRIPTION
With use_retained_scheduling_info enabled, we would schedule checks
which was missed with less than one check_interval, within one
interval_lenght.

This commit introduces a new setting
retained_scheduling_randomize_window which allows users to configure
the window in which checks that were missed over a restart is rescheduled.

This can be useful in order to increase the load balacing done after a
restart, and might be able to help fixing CPU load spikes, due to checks
being unevenly scheduled.

This part of MON-11418

Signed-off-by: Jacob Hansen <jhansen@op5.com>