### PR TITLE
allow NEBERROR_CALLBACKCANCEL from NEBTYPE_*CHECK_INITIATE

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -319,12 +319,12 @@ static int run_async_host_check(host *hst, int check_options, double latency)
 	neb_result = broker_host_check(NEBTYPE_HOSTCHECK_INITIATE, NEBFLAG_NONE, NEBATTR_NONE, hst, CHECK_TYPE_ACTIVE, hst->current_state, hst->state_type, start_time, end_time, hst->check_command, hst->latency, 0.0, host_check_timeout, FALSE, 0, processed_command, NULL, NULL, NULL, cr);
 
 	/* neb module wants to override the service check - perhaps it will check the service itself */
-	if (neb_result == NEBERROR_CALLBACKOVERRIDE) {
+	if (neb_result == NEBERROR_CALLBACKOVERRIDE || neb_result == NEBERROR_CALLBACKCANCEL) {
 		clear_volatile_macros_r(&mac);
 		free_check_result(cr);
 		nm_free(cr);
 		nm_free(processed_command);
-		return OK;
+		return neb_result == NEBERROR_CALLBACKOVERRIDE ? OK : ERROR;
 	}
 
 	runchk_result = wproc_run_callback(processed_command, host_check_timeout, handle_worker_host_check, (void*)cr, &mac);

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -321,12 +321,12 @@ static int run_scheduled_service_check(service *svc, int check_options, double l
 	neb_result = broker_service_check(NEBTYPE_SERVICECHECK_INITIATE, NEBFLAG_NONE, NEBATTR_NONE, svc, CHECK_TYPE_ACTIVE, start_time, end_time, svc->check_command, svc->latency, 0.0, service_check_timeout, FALSE, 0, processed_command, cr);
 
 	/* neb module wants to override the service check - perhaps it will check the service itself */
-	if (neb_result == NEBERROR_CALLBACKOVERRIDE) {
+	if (neb_result == NEBERROR_CALLBACKOVERRIDE || neb_result == NEBERROR_CALLBACKCANCEL) {
 		clear_volatile_macros_r(&mac);
 		free_check_result(cr);
 		nm_free(cr);
 		nm_free(processed_command);
-		return OK;
+		return neb_result == NEBERROR_CALLBACKOVERRIDE ? OK : ERROR;
 	}
 
 	/* paw off the check to a worker to run */


### PR DESCRIPTION
returning NEBERROR_CALLBACKCANCEL  from a NEBTYPE_HOSTCHECK_INITIATE or
NEBTYPE_SERVICECHECK_INITIATE neb callback resulted in naemon running the check
itself. Instead naemon should just skip the check and reschedule it.

Signed-off-by: Sven Nierlein <sven@nierlein.de>