### PR TITLE
fix loading neb module multiple times

### DIFF
--- a/src/naemon/nebmods.c
+++ b/src/naemon/nebmods.c
@@ -180,7 +180,7 @@ int neb_load_module(nebmodule *mod)
 		return ERROR;
 
 	/* load the module */
-	mod->module_handle = dlopen(mod->filename, RTLD_NOW | RTLD_GLOBAL);
+	mod->module_handle = dlopen(mod->filename, RTLD_NOW);
 	if (mod->module_handle == NULL) {
 		nm_log(NSLOG_RUNTIME_ERROR, "Error: Could not load module '%s' -> %s\n", mod->filename, dlerror());
 


### PR DESCRIPTION
loading a neb module multiple times (with different configuration), even from
different files, leads to unwanted results. For example callbacks always
targeted the first loaded module instead of the one which registered the
callback.
This has worked before already, probably because the default used lt_dlopen
without any flags which uses RTLD_LOCAL in fact.
The only scenarion when RTLD_GLOBAL would make sense would be modules which
rely on each other and i am not aware of any module doing something like that.

Signed-off-by: Sven Nierlein <sven@nierlein.de>