### PR TITLE
avoid iterating all services when expanding service lists

### DIFF
--- a/src/naemon/xodtemplate.h
+++ b/src/naemon/xodtemplate.h
@@ -287,6 +287,7 @@ typedef struct xodtemplate_host_struct {
 
     unsigned has_been_resolved : 1;
     unsigned register_object : 1;
+    objectlist *service_list;
     struct xodtemplate_host_struct *next;
 } xodtemplate_host;
 


### PR DESCRIPTION
before this change, expanding wildcards or regular expressions in service lists
resulted in iterating over all services, even for static hostnames. For example
when expanding same host service dependencies still all services will be
checked.
With this patch, we create a shortlist for each hosts services and use that
if possible. Using a example configuration with 80k same host service dependencies
brings down the configuration parsing duration from 20 seconds down to 0.3 seconds.

Signed-off-by: Sven Nierlein <sven@nierlein.de>