### PR TITLE
bail out if members cannot be expaned (fixes #300)

### DIFF
--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -5029,6 +5029,7 @@ static int xodtemplate_recombobulate_hostgroups(void)
 	xodtemplate_hostgroup *temp_hostgroup = NULL;
 	char *hostgroup_names = NULL;
 	char *ptr, *next_ptr, *temp_ptr = NULL;
+	int res;
 
 	/* expand members of all hostgroups - this could be done in xodtemplate_register_hostgroup(), but we can save the CGIs some work if we do it here */
 	for (temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup; temp_hostgroup = temp_hostgroup->next) {
@@ -5078,9 +5079,8 @@ static int xodtemplate_recombobulate_hostgroups(void)
 		}
 
 		/* get list of hosts in the hostgroup */
-		xodtemplate_expand_hosts(&accepted, temp_hostgroup->reject_map, temp_hostgroup->members, temp_hostgroup->_config_file, temp_hostgroup->_start_line);
-
-		if (!accepted && !bitmap_count_set_bits(temp_hostgroup->reject_map)) {
+		res = xodtemplate_expand_hosts(&accepted, temp_hostgroup->reject_map, temp_hostgroup->members, temp_hostgroup->_config_file, temp_hostgroup->_start_line);
+		if (res != OK || (!accepted && !bitmap_count_set_bits(temp_hostgroup->reject_map))) {
 			nm_log(NSLOG_CONFIG_ERROR, "Error: Could not expand members specified in hostgroup (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
 			return ERROR;
 		}
@@ -5211,6 +5211,7 @@ static int xodtemplate_recombobulate_servicegroups(void)
 	xodtemplate_servicegroup *temp_servicegroup = NULL;
 	char *servicegroup_names = NULL;
 	char *temp_ptr;
+	int res;
 
 	/*
 	 * expand servicegroup members. We need this to get the rejected ones
@@ -5260,8 +5261,8 @@ static int xodtemplate_recombobulate_servicegroups(void)
 		}
 
 		/* get list of service members in the servicegroup */
-		xodtemplate_expand_services(&accepted, temp_servicegroup->reject_map, NULL, temp_servicegroup->members, temp_servicegroup->_config_file, temp_servicegroup->_start_line);
-		if (!accepted && !bitmap_count_set_bits(temp_servicegroup->reject_map)) {
+		res = xodtemplate_expand_services(&accepted, temp_servicegroup->reject_map, NULL, temp_servicegroup->members, temp_servicegroup->_config_file, temp_servicegroup->_start_line);
+		if (res != OK || (!accepted && !bitmap_count_set_bits(temp_servicegroup->reject_map))) {
 			nm_log(NSLOG_CONFIG_ERROR, "Error: Could not expand members specified in servicegroup '%s' (config file '%s', starting at line %d)\n", temp_servicegroup->servicegroup_name, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
 			return ERROR;
 		}

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -5727,8 +5727,10 @@ static int xodtemplate_register_host_relations(void *host_, void *discard)
 			host *parent;
 			strip(parent_host);
 			parent = find_host(parent_host);
-			if (add_parent_to_host(new_host, parent) != OK)
+			if (add_parent_to_host(new_host, parent) != OK) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add parent host '%s' to host (config file '%s', starting on line %d)\n", parent_host, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
+				return ERROR;
+			}
 		}
 	}
 

--- a/tests/test-obj-config-parse.c
+++ b/tests/test-obj-config-parse.c
@@ -12,7 +12,6 @@ char *cur_config_file = NULL;
 
 static void init_configuration(void) {
 	int result;
-	FILE *fp;
 
 	/* This is really not used, but needs to be defined */
 	config_file = "(test config filename)";
@@ -22,9 +21,8 @@ static void init_configuration(void) {
 	ck_assert_int_eq(result, OK);
 
 	/* Kick start with a clean config file we can write to with the test */
-	cur_config_file = tempnam(NULL, "nmtst");
-	fp = fopen(cur_config_file, "w");
-	fclose(fp);
+	cur_config_file = strdup("/tmp/nmtst.XXXXXX");
+	close(mkstemp(cur_config_file));
 	add_object_to_objectlist(&objcfg_files, cur_config_file);
 
 }
@@ -152,6 +150,7 @@ START_TEST(test_hostgroup_service_host_override)
 	}
 
 	ck_assert_int_eq(count, 5+1);
+	unlink(cur_config_file);
 }
 END_TEST
 

--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -137,7 +137,6 @@ START_TEST(host_fixed_scheduled_downtime_cancelled)
 
 	ck_assert(OK == unschedule_downtime(HOST_DOWNTIME, downtime_id));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -172,7 +171,6 @@ START_TEST(host_fixed_scheduled_downtime_stopped)
 	 */
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -214,12 +212,10 @@ START_TEST(host_multiple_fixed_scheduled_downtimes)
 
 	ck_assert(OK == handle_scheduled_downtime(dt2));
 	ck_assert_int_eq(1, hst->scheduled_downtime_depth);
-	ck_assert(dt2->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id2));
 
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -261,12 +257,10 @@ START_TEST(host_multiple_fixed_scheduled_downtimes_one_cancelled_one_stopped)
 
 	ck_assert(OK == unschedule_downtime(HOST_DOWNTIME, downtime_id2));
 	ck_assert_int_eq(1, hst->scheduled_downtime_depth);
-	ck_assert(dt2->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id2));
 
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -499,8 +493,6 @@ START_TEST(host_triggered_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -548,8 +540,6 @@ START_TEST(host_triggered_scheduled_downtime_across_reload)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -605,13 +595,10 @@ START_TEST(host_triggered_and_fixed_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does ... */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(1, hst->scheduled_downtime_depth);
 
 	/* ... but the regular downtime has to expire by itself (i.e, it's unaffected by the other ones) */
 	ck_assert(OK == handle_scheduled_downtime(fixed_dt));
-	ck_assert(fixed_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -679,8 +666,6 @@ START_TEST(service_triggered_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, svc->scheduled_downtime_depth);
 	ck_assert_int_eq(0, svc1->scheduled_downtime_depth);
 }

--- a/tests/test-worker.c
+++ b/tests/test-worker.c
@@ -241,6 +241,7 @@ START_TEST(command_worker_launch_shutdown_test)
 	ck_assert_int_eq(0, launch_command_file_worker());
 	worker_pid = command_worker_get_pid();
 	ck_assert_int_ne(0, worker_pid);
+	sleep(1); /* results in race condition on slow boxes otherwise */
 	ck_assert_int_eq(0, shutdown_command_file_worker());
 	ck_assert_int_eq(-1, kill(worker_pid, 0));
 	ck_assert_int_eq(0, command_worker_get_pid());


### PR DESCRIPTION
Configuration validation should bail out if host members cannot be found. Right now it would
print an error but continue. Problem here is that the rest of the list is not parsed, so the
first unknown host cuts off the members list.
Same applies to servicegroup members.

Signed-off-by: Sven Nierlein <sven@nierlein.de>