### PR TITLE
fix downtime tests

### DIFF
--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -137,7 +137,6 @@ START_TEST(host_fixed_scheduled_downtime_cancelled)
 
 	ck_assert(OK == unschedule_downtime(HOST_DOWNTIME, downtime_id));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -172,7 +171,6 @@ START_TEST(host_fixed_scheduled_downtime_stopped)
 	 */
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -214,12 +212,10 @@ START_TEST(host_multiple_fixed_scheduled_downtimes)
 
 	ck_assert(OK == handle_scheduled_downtime(dt2));
 	ck_assert_int_eq(1, hst->scheduled_downtime_depth);
-	ck_assert(dt2->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id2));
 
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -266,7 +262,6 @@ START_TEST(host_multiple_fixed_scheduled_downtimes_one_cancelled_one_stopped)
 
 	ck_assert(OK == handle_scheduled_downtime(dt));
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
-	ck_assert(dt->is_in_effect == FALSE);
 	ck_assert(NULL == find_downtime(ANY_DOWNTIME, downtime_id));
 }
 END_TEST
@@ -499,8 +494,6 @@ START_TEST(host_triggered_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -548,8 +541,6 @@ START_TEST(host_triggered_scheduled_downtime_across_reload)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -605,13 +596,10 @@ START_TEST(host_triggered_and_fixed_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does ... */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(1, hst->scheduled_downtime_depth);
 
 	/* ... but the regular downtime has to expire by itself (i.e, it's unaffected by the other ones) */
 	ck_assert(OK == handle_scheduled_downtime(fixed_dt));
-	ck_assert(fixed_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, hst->scheduled_downtime_depth);
 }
 END_TEST
@@ -679,8 +667,6 @@ START_TEST(service_triggered_scheduled_downtime)
 
 	/* ... and the triggered downtime should expire when the first downtime does */
 	ck_assert(OK == handle_scheduled_downtime(dt));
-	ck_assert(dt->is_in_effect == FALSE);
-	ck_assert(triggered_dt->is_in_effect == FALSE);
 	ck_assert_int_eq(0, svc->scheduled_downtime_depth);
 	ck_assert_int_eq(0, svc1->scheduled_downtime_depth);
 }

--- a/tests/test-worker.c
+++ b/tests/test-worker.c
@@ -241,6 +241,7 @@ START_TEST(command_worker_launch_shutdown_test)
 	ck_assert_int_eq(0, launch_command_file_worker());
 	worker_pid = command_worker_get_pid();
 	ck_assert_int_ne(0, worker_pid);
+	sleep(1); /* results in race condition on slow boxes otherwise */
 	ck_assert_int_eq(0, shutdown_command_file_worker());
 	ck_assert_int_eq(-1, kill(worker_pid, 0));
 	ck_assert_int_eq(0, command_worker_get_pid());


### PR DESCRIPTION
it is unsafe to access the downtimes after they have been removed because this
frees the underlaying memory. This might work sometimes if the memory has not
been reused meanwhile but is undefined behaviour.
The effect of has been asserted indirectly through the affected hosts/service already.

Signed-off-by: Sven Nierlein <sven@nierlein.de>