### PR TITLE
Don't process perfdata file if perfdata is disabled

### DIFF
--- a/src/naemon/perfdata.c
+++ b/src/naemon/perfdata.c
@@ -575,6 +575,9 @@ static void xpddefault_process_host_perfdata_file(struct nm_event_execution_prop
 		if (host_perfdata_file_processing_command == NULL)
 			return; /* OK */
 
+		if (process_performance_data == FALSE)
+			return; /* OK */
+
 		/* init macros */
 		memset(&mac, 0, sizeof(mac));
 
@@ -637,6 +640,9 @@ static void xpddefault_process_service_perfdata_file(struct nm_event_execution_p
 
 		/* we don't have a command */
 		if (service_perfdata_file_processing_command == NULL)
+			return; /* OK */
+
+		if (process_performance_data == FALSE)
 			return; /* OK */
 
 		/* init macros */


### PR DESCRIPTION
Currently, even if `process_performance_data` is set to 0, the commands
set by `host/service_perfdata_file_processing_command` are executed.
Often these file processing commands move the current perfdata files to
a spool directory. These files will be empty if
`process_performance_data` is set to 0. Given the files are empty
anyway, it does not make a lot of sense to process the perfdata files.
Furthermore, if no software is cleaning up the empty files from the spool
directory, the system will eventually be flooded with empty files.

This commit fixes the above behaviour by not executing the file
processing commands if performance data processing is disabled.