### PR TITLE
fix using pipes in commands (fixes #319)

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -315,6 +315,9 @@ void runcmd_init(void)
 	}
 #endif
 
+	/* reset pipe handling so child processes can use shell pipes */
+	signal(SIGPIPE, SIG_DFL);
+
 	if (!pids)
 		pids = calloc(maxfd, sizeof(pid_t));
 }


### PR DESCRIPTION
using a simple shell script like this runs into timeout when run
by naemon because SIGPIPE is beeing ignored for unknown reasons.

```

random-string()
{
  /bin/cat /dev/urandom | /bin/tr -dc 'a-zA-Z0-9' | /bin/fold -w ${1:-32} | /bin/head -n 1
}

echo "OK - rand: $(random-string)"
exit 0
```

using the default signal handling right before we run child commands fixes this.