### PR TITLE
fix crash in DEL_DOWNTIME_BY_HOSTGROUP_NAME

### DIFF
--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -1776,13 +1776,13 @@ static void foreach_contact_in_contactgroup(contactgroup *target_contactgroup, v
 }
 
 struct matches_arg {
-	struct external_command *ext_command;
+	const struct external_command *ext_command;
 	int deleted;
 };
 static gboolean delete_if_matches(gpointer _name, gpointer _hst, gpointer user_data)
 {
 	struct matches_arg *match = (struct matches_arg *)user_data;
-	struct external_command *ext_command = match->ext_command;
+	const struct external_command *ext_command = match->ext_command;
 	host *host_ptr = (host *)_hst;
 	if (strcmp(GV_STRING("hostname"), "") && !strcmp(host_ptr->name, GV("hostname")))
 		return FALSE;
@@ -1798,7 +1798,7 @@ static gboolean delete_if_matches(gpointer _name, gpointer _hst, gpointer user_d
 static int del_downtime_by_filter_handler(const struct external_command *ext_command, time_t entry_time)
 {
 	hostgroup *hostgroup_p = NULL;
-	struct matches_arg match;
+	struct matches_arg match = { ext_command, 0 };
 	switch (ext_command->id) {
 		case CMD_DEL_DOWNTIME_BY_HOST_NAME:
 			if(delete_downtime_by_hostname_service_description_start_time_comment(

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -1787,7 +1787,7 @@ static gboolean delete_if_matches(gpointer _name, gpointer _hst, gpointer user_d
 	if (strcmp(GV_STRING("hostname"), "") && !strcmp(host_ptr->name, GV("hostname")))
 		return FALSE;
 	match->deleted += delete_downtime_by_hostname_service_description_start_time_comment(
-		!strcmp(GV_STRING("hostname"), "") ? NULL : GV("hostname"),
+		!strcmp(GV_STRING("hostname"), "") ? (char *)_name : GV("hostname"),
 		!strcmp(GV_STRING("service_description"), "") ? NULL : GV("service_description"),
 		GV_TIMESTAMP("downtime_start_time"),
 		!strcmp(GV_STRING("comment"), "") ? NULL : GV("comment")


### PR DESCRIPTION
uninitialised struct causes dereference to random addresses.

I first thought this was due to supplying too few parameters (Icinga 1 only requires one, the hostgroup), but this command would never work, I think.
