### PR TITLE
correct signal handler return type

### DIFF
--- a/lib/test-iobroker.c
+++ b/lib/test-iobroker.c
@@ -108,7 +108,7 @@ static int listen_handler(int fd, int events, void *arg)
 	return 0;
 }
 
-int sighandler(int sig)
+void sighandler(int sig)
 {
 	/* test failed */
 	t_fail("Caught signal %d", sig);


### PR DESCRIPTION
fixes:
```
lib/test-iobroker.c: In function ‘conn_spam’:
lib/test-iobroker.c:125:18: error: cast between incompatible function types from ‘int (*)(int)’ to ‘void (*)(int)’ [-Werror=cast-function-type]
  125 |  signal(SIGALRM, (void (*)(int))sighandler);
      |                  ^
lib/test-iobroker.c:126:17: error: cast between incompatible function types from ‘int (*)(int)’ to ‘void (*)(int)’ [-Werror=cast-function-type]
  126 |  signal(SIGINT, (void (*)(int))sighandler);
      |                 ^
```

Signed-off-by: Sven Nierlein <sven@nierlein.de>