### PR TITLE
fixed various memory leaks in naemonstats

### DIFF
--- a/src/naemonstats/naemonstats.c
+++ b/src/naemonstats/naemonstats.c
@@ -10,6 +10,7 @@
 #include "config.h"
 #include <naemon/common.h>
 #include <naemon/defaults.h>
+#include <naemon/nm_alloc.h>
 
 #define STATUS_NO_DATA             0
 #define STATUS_INFO_DATA           1
@@ -834,8 +835,7 @@ static int read_config_file(void)
 
 	fp = fopen(main_config_file, "r");
 	if (fp == NULL) {
-	    if (main_cfg_dir)
-	        free(main_cfg_dir);
+	    nm_free(main_cfg_dir);
 	    return ERROR;
 	}
 
@@ -863,11 +863,10 @@ static int read_config_file(void)
 	fclose(fp);
 
 	//free
-	/* transfer of owner ship
+	/* we are responsible for freeing the memory
 	 * malloc in nspath.c -> pcomp_construct
 	 */
-	if(main_cfg_dir)
-	    free(main_cfg_dir);
+	nm_free(main_cfg_dir);
 
 	return OK;
 }
@@ -1389,18 +1388,9 @@ void get_time_breakdown(unsigned long raw_time, int *days, int *hours, int *minu
 static void free_memory(void)
 {
     //deallocate memory
-    if (main_config_file)
-        free(main_config_file);
-
-    if (status_file)
-        free(status_file);
-
-    if (status_version)
-        free(status_version);
-
-    if(mrtg_variables)
-        free(mrtg_variables);
-
-    if(mrtg_delimiter_save)
-        free(mrtg_delimiter_save);
+    nm_free(main_config_file);
+    nm_free(status_file);
+    nm_free(status_version);
+    nm_free(mrtg_variables);
+    nm_free(mrtg_delimiter_save);
 }

--- a/src/naemonstats/naemonstats.c
+++ b/src/naemonstats/naemonstats.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
 			break;
 		case 'D':
 		    mrtg_delimiter_save = strdup(optarg);
-			mrtg_delimiter = mrtg_delimiter_save;
+		    mrtg_delimiter = mrtg_delimiter_save;
 			break;
 
 		default:


### PR DESCRIPTION
Hi guys,

i fell over some memory leaks in "neamonstats" and fixed it. Please be so kind and review my request.

i tried nearly all variations of parameters from "naemonstats" with valgrind. This is the result:

### **Call 1:**
```
/usr/local/bin/naemonstats -s /var/lib/naemon/status.dat
/usr/local/bin/naemonstats -c /etc/naemon/naemon.cfg
```

**Memory Leak main_config_file:**
```
==7514== 27 bytes in 1 blocks are still reachable in loss record 3 of 9
==7514==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7514==    by 0x53859B9: strdup (strdup.c:42)
==7514==    by 0x108FD1: main (naemonstats.c:235)
```

**Memory Leaks status_file:**
```
==7514== 33 bytes in 1 blocks are still reachable in loss record 5 of 9
==7514==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7514==    by 0x53859B9: strdup (strdup.c:42)
==7514==    by 0x108EFA: main (naemonstats.c:207)
```
```
==7514== 6 bytes in 1 blocks are still reachable in loss record 2 of 9
==7514==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7514==    by 0x53859B9: strdup (strdup.c:42)
==7514==    by 0x10BF9C: read_status_file (naemonstats.c:1161)
==7514==    by 0x10901F: main (naemonstats.c:378)
```

**Memory Leaks status_version:**
```
==13487== 6 bytes in 1 blocks are still reachable in loss record 2 of 7
==13487==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13487==    by 0x574C9B9: strdup (strdup.c:42)
==13487==    by 0x10D100: read_status_file (naemonstats.c:1174)
==13487==    by 0x109667: main (naemonstats.c:380)
```

**Call 1 Re-Check:**
```
==29509== Memcheck, a memory error detector
==29509== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==29509== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==29509== Command: /usr/local/bin/naemonstats -s /var/lib/naemon/status.dat
==29509== Parent PID: 6961
==29509== 
==29509== 
==29509== HEAP SUMMARY:
==29509==     in use at exit: 18,604 bytes in 6 blocks
==29509==   total heap usage: 12 allocs, 6 frees, 24,342 bytes allocated
==29509== 
==29509== LEAK SUMMARY:
==29509==    definitely lost: 0 bytes in 0 blocks
==29509==    indirectly lost: 0 bytes in 0 blocks
==29509==      possibly lost: 0 bytes in 0 blocks
==29509==    still reachable: 18,604 bytes in 6 blocks
==29509==         suppressed: 0 bytes in 0 blocks
==29509== Rerun with --leak-check=full to see details of leaked memory
==29509== 
==29509== For counts of detected and suppressed errors, rerun with: -v
==29509== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

```

-------------------------------------------------------------------------------------------------

### Call 2: 
`/usr/local/bin/naemonstats`

**Memory Leak main_cfg_dir:**
Method "pcomp_construct" allocates memory and returns a pointer. So the caller has to free the memory on purpose.

```
==9990== 35 bytes in 1 blocks are definitely lost in loss record 3 of 7
==9990==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9990==    by 0x4ECDCE8: pcomp_construct (nspath.c:48)
==9990==    by 0x4ECE0BC: nspath_normalize (nspath.c:130)
==9990==    by 0x4ECE142: nspath_absolute (nspath.c:146)
==9990==    by 0x10BECC: read_config_file (naemonstats.c:837)
==9990==    by 0x10960F: main (naemonstats.c:370)
```

**Call 2 fixed:**
```

==12501== Memcheck, a memory error detector
==12501== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12501== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==12501== Command: /usr/local/bin/naemonstats
==12501== 


Naemon Stats 1.2.0.g9308955f.20200511.source
Copyright (c) 2013-present Naemon Development Team (www.naemon.org)
Copyright (c) 2003-2008 Ethan Galstad (www.nagios.org)
License: GPL

Error reading status file '/usr/local/var/status.dat': No such file or directory
==12501== 
==12501== HEAP SUMMARY:
==12501==     in use at exit: 18,604 bytes in 6 blocks
==12501==   total heap usage: 17 allocs, 11 frees, 25,159 bytes allocated
==12501== 
==12501== LEAK SUMMARY:
==12501==    definitely lost: 0 bytes in 0 blocks
==12501==    indirectly lost: 0 bytes in 0 blocks
==12501==      possibly lost: 0 bytes in 0 blocks
==12501==    still reachable: 18,604 bytes in 6 blocks
==12501==         suppressed: 0 bytes in 0 blocks
==12501== Reachable blocks (those to which a pointer was found) are not shown.
==12501== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==12501== 
==12501== For counts of detected and suppressed errors, rerun with: -v
==12501== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
---------------------------------------------------------------------------------------------------

### Call 3:
` /usr/local/bin/naemonstats -h`

**Memory Leak main_cfg_file:**
```
==12604== 33 bytes in 1 blocks are still reachable in loss record 3 of 7
==12604==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12604==    by 0x574C9B9: strdup (strdup.c:42)
==12604==    by 0x108FE0: main (naemonstats.c:207)
```
---------------------------------------------------------------------------------------------------

### Call 4:
` /usr/local/bin/naemonstats -s /var/lib/naemon/status.dat -d PROGRUNTIME`

**Memory Leak:**
```
==17882== 12 bytes in 1 blocks are still reachable in loss record 2 of 7
==17882==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17882==    by 0x574C9B9: strdup (strdup.c:42)
==17882==    by 0x1090EC: main (naemonstats.c:241)

```
Fixed!

---------------------------------------------------------------------------------------------------

i do not post the valgrind output of every fix as this won't be necessary and will only expand the message. furthermore, i adjusted some pointer and char array initialization.

let me know if i can provide you with any further information.

thanks!