### PR TITLE
Worker: Null pointer sanity check before wlog call

### DIFF
--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -388,7 +388,12 @@ static void gather_output(child_process *cp, iobuf *io, int final)
 				/* broken system or no more data. Just return */
 				return;
 			}
-			wlog("job %d (pid=%d): Failed to read(): %s", cp->id, cp->ei->pid, strerror(errno));
+			/* Null pointer check before printing */
+			if (cp && cp->ei) {
+				wlog("job %d (pid=%d): Failed to read(): %s", cp->id, cp->ei->pid, strerror(errno));
+			} else {
+				wlog("Unknown job: Failed to read(): %s", strerror(errno));
+			}
 		}
 
 		/*


### PR DESCRIPTION
This commit implements a couple of sanity checks on pointers in the
worker process. This is the result of analyzing core-dumps from a crash.