### PR TITLE
debian: install systemd service

### DIFF
--- a/debian/naemon-core.install
+++ b/debian/naemon-core.install
@@ -1,6 +1,7 @@
 /etc/init.d/naemon
 /etc/naemon/naemon.cfg
 /etc/naemon/resource.cfg
+/etc/naemon/module-conf.d
 /usr/bin/naemon
 /usr/bin/naemonstats
 /var/log/naemon

--- a/debian/naemon-core.naemon.service
+++ b/debian/naemon-core.naemon.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Naemon Monitoring Daemon
+Documentation=http://naemon.org/documentation
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/naemon
+Type=forking
+PIDFile=/run/naemon/naemon.pid
+PermissionsStartOnly=true
+ExecStartPre=-/bin/mkdir -p /var/run/naemon
+ExecStartPre=/bin/chown -R naemon:naemon /run/naemon/
+ExecStartPre=/bin/su naemon --login --shell=/bin/sh "--command=/usr/bin/naemon --verify-config /etc/naemon/naemon.cfg"
+ExecStart=/usr/bin/naemon --daemon /etc/naemon/naemon.cfg
+ExecReload=/bin/kill -HUP $MAINPID
+User=naemon
+Group=naemon
+StandardOutput=journal
+StandardError=inherit
+
+[Install]
+WantedBy=multi-user.target
+

--- a/debian/naemon-core.naemon.tmpfiles
+++ b/debian/naemon-core.naemon.tmpfiles
@@ -1,0 +1,3 @@
+D /run/naemon 0755 naemon naemon -
+r /var/cache/naemon/checkresults/* 0644 naemon naemon 1d
+

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,7 @@ override_dh_auto_configure:
 				--with-logrotatedir="/etc/logrotate.d" \
 				--with-naemon-user="naemon" \
 				--with-naemon-group="naemon" \
-				--with-lockfile="/var/run/naemon/naemon.pid"
+				--with-lockfile="/run/naemon/naemon.pid"
 	if [ "x$(DEB_HOST_MULTIARCH)" != "x" ]; then \
 		echo /usr/lib/naemon/pkgconfig/naemon.pc usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/ >> debian/naemon-dev.install; \
 	else \
@@ -37,6 +37,7 @@ override_dh_auto_configure:
 	fi
 	if [ "x$(WITH_SYSTEMD)" != "x" ]; then \
 		echo "/usr/bin/naemon-ctl" >> debian/naemon-core.install; \
+		echo "/etc/default/naemon" >> debian/naemon-core.install; \
 	fi
 
 
@@ -59,8 +60,8 @@ override_dh_auto_install:
 	sed -i "/dependency_libs/ s/'.*'/''/" `find . -name '*.la'`
 	# Move SystemV init-script
 	if [ "x$(WITH_SYSTEMD)" != "x" ]; then \
-		mkdir -p -m 0755 debian/tmp; \
-		install -m 755 debian/naemon-core.naemon.init debian/tmp/usr/bin/naemon-ctl; \
+		install -D -m 0755 debian/naemon-core.naemon.init debian/tmp/usr/bin/naemon-ctl; \
+		install -D -m 0644 sample-config/naemon.sysconfig debian/tmp/etc/default/naemon; \
 	fi
 
 override_dh_gencontrol:

--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,7 @@ override_dh_auto_install:
 		install -D -m 0755 debian/naemon-core.naemon.init debian/tmp/usr/bin/naemon-ctl; \
 		install -D -m 0644 sample-config/naemon.sysconfig debian/tmp/etc/default/naemon; \
 	fi
+	mkdir -p -m 0755 debian/tmp/etc/naemon/module-conf.d
 
 override_dh_gencontrol:
 	dh_gencontrol


### PR DESCRIPTION
debian uses systemd and should therefor use systemd service as well.

Signed-off-by: Sven Nierlein <Sven.Nierlein@consol.de>