### PR TITLE
Travis: Add slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,28 @@
 language: c
 compiler:
-  - gcc
-# Change this to your needs
+- gcc
 install:
-  - sudo apt-get install autoconf
-  - sudo apt-get install build-essential
-  - sudo apt-get install gperf
-  - sudo apt-get install check
-  - sudo apt-get install help2man
-  - sudo apt-get install python-pip
-  - sudo pip install behave flake8
+- sudo apt-get install autoconf
+- sudo apt-get install build-essential
+- sudo apt-get install gperf
+- sudo apt-get install check
+- sudo apt-get install help2man
+- sudo apt-get install python-pip
+- sudo pip install behave flake8
 before_script:
-  - ./autogen.sh
-  - make
+- "./autogen.sh"
+- make
 script:
-  - make check
-  - make distcheck
-  - flake8
-  - behave
+- make check
+- make distcheck
+- flake8
+- behave
 notifications:
   irc:
     channels:
-      - "chat.freenode.net#naemon-devel"
+    - chat.freenode.net#naemon-devel
     on_success: change
     on_failure: always
     skip_join: true
+  slack:
+    secure: rHm9X/62NvsnmIWEZZUCrxn126qaiRRtT3R201VCHQKwuxlk76cM3qRjSPVKE0CILGcjKrr2wy/2/s/2zMhXmxroFGGilNYiBq32PEti2XKOJQ0pDHJeDNCU+iPQz/dmmjIrXCGTT5W9eQzE2GKheXlvFzXTZO+z/wsEFqWO+Fw=


### PR DESCRIPTION
With this commit slack notification is posted from travis to `#naemon-travis` at the Openmonitoring slack channel.

The travis CLI tools also reformatted the .travis file slightly - I assume with the "correct" formatting.