### PR TITLE
fix next_check synchronisation

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -122,6 +122,7 @@ void schedule_next_host_check(host *hst, time_t delay, int options)
 	/* Schedule the event */
 	hst->check_options = options;
 	hst->next_check = delay + current_time;
+	hst->last_update = current_time;
 	hst->next_check_event = schedule_event(delay, handle_host_check_event, (void *)hst);
 
 	/* update the status log, since next_check and check_options is updated */

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -124,6 +124,7 @@ void schedule_next_service_check(service *svc, time_t delay, int options)
 	/* Schedule the event */
 	svc->check_options = options;
 	svc->next_check = delay + current_time;
+	svc->last_update = current_time;
 	svc->next_check_event = schedule_event(delay, handle_service_check_event, (void *)svc);
 
 	/* update the status log, since next_check and check_options is updated */


### PR DESCRIPTION
last_update wasn't updated in some cases when only the next_check advances. For example for
pending and disabled hosts/services.
This patch ensures, that whenever next_check is updated, also last_update is set.