### PR TITLE
debian: move to systemd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: naemon-core
 Section: net
 Priority: optional
 Maintainer: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
-Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config, libglib2.0-dev, fakeroot, autoconf, automake, libtool
+Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config,
+  libglib2.0-dev, fakeroot, autoconf, automake, libtool, dh-systemd
 Standards-Version: 3.7.3
 Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon-core/issues

--- a/debian/naemon-core.dsc
+++ b/debian/naemon-core.dsc
@@ -8,7 +8,8 @@ Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon-core/issues
 Vcs-Browser: https://github.com/naemon/naemon-core
 Vcs-Git: git://github.com:naemon/naemon-core.git
-Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config, libglib2.0-dev, fakeroot, autoconf, automake, libtool
+Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config,
+  libglib2.0-dev, fakeroot, autoconf, automake, libtool, dh-systemd
 Files:
    00000000000000000000000000000000 0000 naemon_1.0.0.orig.tar.gz
    00000000000000000000000000000000 0000 naemon_1.0.0-1.diff.tar.gz

--- a/debian/naemon-core.install
+++ b/debian/naemon-core.install
@@ -1,8 +1,10 @@
+/etc/default/naemon
 /etc/init.d/naemon
 /etc/naemon/naemon.cfg
 /etc/naemon/resource.cfg
 /etc/naemon/module-conf.d
 /usr/bin/naemon
+/usr/bin/naemon-ctl
 /usr/bin/naemonstats
 /var/log/naemon
 /var/log/naemon/archives

--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,6 @@
 export DH_VERBOSE=1
 DESTDIR=$(CURDIR)/debian/tmp/
 
-WITH_SYSTEMD=$(shell if [ -x "/bin/systemctl" ]; then echo "--with systemd"; else echo ""; fi )
-
 override_dh_auto_configure:
 	test -f configure || ./autogen.sh
 	dh_auto_configure -- --prefix=/usr \
@@ -35,10 +33,6 @@ override_dh_auto_configure:
 	else \
 		echo /usr/lib/naemon/pkgconfig/naemon.pc usr/share/pkgconfig/ >> debian/naemon-dev.install; \
 	fi
-	if [ "x$(WITH_SYSTEMD)" != "x" ]; then \
-		echo "/usr/bin/naemon-ctl" >> debian/naemon-core.install; \
-		echo "/etc/default/naemon" >> debian/naemon-core.install; \
-	fi
 
 
 
@@ -59,10 +53,8 @@ override_dh_auto_install:
 	# get rid of dependency_libs in la files, see https://wiki.debian.org/ReleaseGoals/LAFileRemoval
 	sed -i "/dependency_libs/ s/'.*'/''/" `find . -name '*.la'`
 	# Move SystemV init-script
-	if [ "x$(WITH_SYSTEMD)" != "x" ]; then \
-		install -D -m 0755 debian/naemon-core.naemon.init debian/tmp/usr/bin/naemon-ctl; \
-		install -D -m 0644 sample-config/naemon.sysconfig debian/tmp/etc/default/naemon; \
-	fi
+	install -D -m 0755 debian/naemon-core.naemon.init debian/tmp/usr/bin/naemon-ctl
+	install -D -m 0644 sample-config/naemon.sysconfig debian/tmp/etc/default/naemon
 	mkdir -p -m 0755 debian/tmp/etc/naemon/module-conf.d
 
 override_dh_gencontrol:


### PR DESCRIPTION
The oldest supported system is ubuntu14.04 on obs right now and even that supports systemd already. So
simply move to systemd completely. Detection of system failed on obs on some systems and the packages
end up with half complete systemd integration.

dh_installinit install service anyway, even if we do not add the other systemd files.

  [  144s] dh_installinit --name=naemon
  [  144s] 	install -d debian/naemon-core/lib/systemd/system
  [  144s] 	install -p -m0644 debian/naemon-core.naemon.service debian/naemon-core/lib/systemd/system/naemon.service