### PR TITLE
Fix header file location in deb/rpm packages

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ override_dh_auto_configure:
 				--bindir="/usr/bin" \
 				--datadir="/usr/share/naemon" \
 				--libdir="/usr/lib/naemon" \
-				--includedir="/usr/include/naemon" \
+				--includedir="/usr/include" \
 				--localstatedir="/var/lib/naemon" \
 				--sysconfdir="/etc/naemon" \
 				--with-naemon-config-dir="/etc/naemon/module-conf.d" \

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -111,7 +111,7 @@ test -f configure || ./autogen.sh
 CFLAGS="%{mycflags}" LDFLAGS="$CFLAGS" %configure \
     --datadir="%{_datadir}/naemon" \
     --libdir="%{_libdir}/naemon" \
-    --includedir="%{_includedir}/naemon" \
+    --includedir="%{_includedir}" \
     --localstatedir="%{_localstatedir}/lib/naemon" \
     --sysconfdir="%{_sysconfdir}/naemon" \
     --with-naemon-config-dir="%{_sysconfdir}/naemon/module-conf.d" \


### PR DESCRIPTION
Automake automatically adds a package name suffix to `includedir` so it
should be specified as "/usr/include" not "/usr/include/naemon".

Fixes #299.