### PR TITLE
dh-systemd has been merged into debhelper

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
 Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config,
-  libglib2.0-dev, fakeroot, autoconf, automake, libtool, dh-systemd
+  libglib2.0-dev, fakeroot, autoconf, automake, libtool
 Standards-Version: 3.7.3
 Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon-core/issues

--- a/debian/naemon-core.dsc
+++ b/debian/naemon-core.dsc
@@ -9,7 +9,7 @@ Bugs: https://github.com/naemon/naemon-core/issues
 Vcs-Browser: https://github.com/naemon/naemon-core
 Vcs-Git: git://github.com:naemon/naemon-core.git
 Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config,
-  libglib2.0-dev, fakeroot, autoconf, automake, libtool, dh-systemd
+  libglib2.0-dev, fakeroot, autoconf, automake, libtool
 Files:
    00000000000000000000000000000000 0000 naemon_1.0.0.orig.tar.gz
    00000000000000000000000000000000 0000 naemon_1.0.0-1.diff.tar.gz


### PR DESCRIPTION
it is obsolete since stretch and removed in debian 11.