### PR TITLE
Fix stopping Naemon in logging feature test

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,6 @@
 from support.naemon_object_config import NaemonObjectConfig
 from support.naemon_system_config import NaemonSystemConfig
+from support import slurp_file
 import tempfile
 import os
 import os.path
@@ -38,7 +39,7 @@ def before_scenario(context, scenario):
 def after_scenario(context, scenario):
     # Kill any naemon daemonsv
     if os.path.isfile('naemon.pid'):
-        pid = int(open('naemon.pid').read())
+        pid = int(slurp_file('naemon.pid'))
         try:
             os.kill(pid, signal.SIGTERM)
             print('Killed the naemon process (%i)' % pid)

--- a/features/logging.feature
+++ b/features/logging.feature
@@ -8,7 +8,7 @@ Feature: Logging
         Then naemon should output a sensible error message
 
     Scenario: Output retention data log message when stopped
-        Given I start naemon
+        Given I start naemon and wait until it is ready
         When I stop naemon
         And I wait for 5 seconds
         Then naemon should not be running

--- a/features/restart.feature
+++ b/features/restart.feature
@@ -2,7 +2,7 @@ Feature: Restart
     Naemon can be restarted without killing the process
 
     Scenario: Naemon is restarted when sending SIGHUP to process
-        Given I start naemon
+        Given I start naemon and wait until it is ready
         When I restart naemon
         And I wait for 10 seconds
         Then naemon should be running

--- a/features/steps/filesystem.py
+++ b/features/steps/filesystem.py
@@ -1,4 +1,5 @@
 from behave import given, use_step_matcher
+import os
 import os.path
 
 use_step_matcher('re')

--- a/features/support/__init__.py
+++ b/features/support/__init__.py
@@ -1,0 +1,4 @@
+def slurp_file(file_or_path, mode="r"):
+    """Open file for reading and return contents."""
+    with open(str(file_or_path), mode) as fp:
+        return fp.read().strip()


### PR DESCRIPTION
We noticed that logging tests failed when building in a new environment, it seemed to be a timing issue where the test case wants to SIGTERM naemon, but some investigation gave that naemon didn't completely start yet, so its signal handlers weren't installed and thus didn't stop as intended. This is an attempt to improve the timing issue.

* Fix test that failed if Naemon haven't yet started correctly and got
  it's signal handlers setup at the stage a test case executes the "When
  I stop naemon" step.
  Add a step that starts Naemon and wait until it finds a line in the
  log file that indicates that it should be ready.
  It's not perfect, but it seems to make the test case more stable.

* Close opened files in feature tests.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>