### PR TITLE
speed up cleanup() when having servicegroups

### DIFF
--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -408,6 +408,7 @@ int main(int argc, char **argv)
 		}
 
 		/* clean up after ourselves */
+		timing_point("Cleaning up\n");
 		cleanup();
 
 		/* exit */

--- a/src/naemon/objects_service.h
+++ b/src/naemon/objects_service.h
@@ -145,12 +145,12 @@ static const struct flag_map service_flag_map[] = {
 };
 
 int init_objects_service(int elems);
-void destroy_objects_service(void);
+void destroy_objects_service(int truncate_lists);
 
 service *create_service(host *hst, const char *description);
 int setup_service_variables(service *svc, const char *display_name, const char *check_period, const char *check_command, int initial_state, int max_attempts, int accept_passive_checks, double check_interval, double retry_interval, double notification_interval, double first_notification_delay, char *notification_period, int notification_options, int notifications_enabled, int is_volatile, const char *event_handler, int event_handler_enabled, int checks_enabled, int flap_detection_enabled, double low_flap_threshold, double high_flap_threshold, int flap_detection_options, int stalking_options, int process_perfdata, int check_freshness, int freshness_threshold, const char *notes, const char *notes_url, const char *action_url, const char *icon_image, const char *icon_image_alt, int retain_status_information, int retain_nonstatus_information, int obsess, unsigned int hourly_value);
 int register_service(service *new_service);
-void destroy_service(service *svc);
+void destroy_service(service *svc, int truncate_lists);
 
 struct contactgroupsmember *add_contactgroup_to_service(service *, char *);					/* adds a contact group to a service definition */
 struct contactsmember *add_contact_to_service(service *, char *);                                              /* adds a contact to a host definition */

--- a/src/naemon/objects_servicegroup.h
+++ b/src/naemon/objects_servicegroup.h
@@ -32,11 +32,11 @@ struct servicegroup {
 };
 
 int init_objects_servicegroup(int elems);
-void destroy_objects_servicegroup(void);
+void destroy_objects_servicegroup(int truncate_lists);
 
 servicegroup *create_servicegroup(const char *name, const char *alias, const char *notes, const char *notes_url, const char *action_url);
 int register_servicegroup(servicegroup *this_servicegroup);
-void destroy_servicegroup(servicegroup *this_servicegroup);
+void destroy_servicegroup(servicegroup *this_servicegroup, int truncate_lists);
 struct servicesmember *add_service_to_servicegroup(servicegroup *, service *);
 void remove_service_from_servicegroup(servicegroup *temp_servicegroup, service *svc);
 

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -967,11 +967,11 @@ void free_memory(nagios_macros *mac)
 	destroy_objects_command();
 	destroy_objects_timeperiod();
 	destroy_objects_host();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_objects_contact();
 	destroy_objects_contactgroup();
 	destroy_objects_hostgroup();
-	destroy_objects_servicegroup();
+	destroy_objects_servicegroup(TRUE);
 
 	free_comment_data();
 

--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -46,7 +46,7 @@ void setup_check_result(void)
 void destroy_objects(void)
 {
 	destroy_objects_host();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 }
 
 void setup_objects(time_t when)

--- a/t-tap/test_downtime.c
+++ b/t-tap/test_downtime.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
 	ok(i == 0, "No downtimes left, Left: %d", i);
 
 	destroy_objects_host();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_event_queue();
 	cleanup_downtime_data();
 	free_comment_data();

--- a/tests/test-check-dependencies.c
+++ b/tests/test-check-dependencies.c
@@ -53,7 +53,7 @@ void teardown(void)
 {
 	destroy_event_queue();
 	destroy_objects_command();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_objects_host();
 }
 

--- a/tests/test-check-result-processing.c
+++ b/tests/test-check-result-processing.c
@@ -42,7 +42,7 @@ void teardown(void)
 {
 	destroy_event_queue();
 	destroy_objects_command();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_objects_host();
 }
 

--- a/tests/test-check-scheduling.c
+++ b/tests/test-check-scheduling.c
@@ -76,7 +76,7 @@ void teardown(void)
 {
 	destroy_event_queue();
 	destroy_objects_command();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_objects_host();
 }
 

--- a/tests/test-neb-callbacks.c
+++ b/tests/test-neb-callbacks.c
@@ -130,7 +130,7 @@ void setup_v2(void)
 void teardown_v1(void)
 {
 	common_teardown();
-	destroy_service(svc);
+	destroy_service(svc, FALSE);
 	destroy_host(hst);
 	free_check_result(cr);
 	nm_free(cr);

--- a/tests/test-retention.c
+++ b/tests/test-retention.c
@@ -45,7 +45,7 @@ void teardown_objects(void)
 
 	destroy_objects_command();
 	destroy_objects_host();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 
 }
 

--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -94,7 +94,7 @@ void teardown(void)
 {
 
 	destroy_objects_command();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	destroy_objects_host();
 	cleanup_retention_data();
 	cleanup_downtime_data();


### PR DESCRIPTION
while clean up we iterate over all services and each service is removed from
all its servicegroups by iterating over the servicegroup members over and over
to remove each service one by one.
Adding a new flag truncate_lists which can be set on teardown to simply iterate once
over each list and remove/free all items.
This reduces the duration of a config check for an example config with 100k services from
30seconds to less than 3seconds.

Signed-off-by: Sven Nierlein <sven@nierlein.de>