### PR TITLE
Correclty set svc check_command for broker call

### DIFF
--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -1039,7 +1039,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	    temp_service->check_type,
 	    queued_check_result->start_time,
 	    queued_check_result->finish_time,
-	    NULL,
+	    temp_service->check_command,
 	    temp_service->latency,
 	    temp_service->execution_time,
 	    service_check_timeout,


### PR DESCRIPTION
This commit fixes a bug where the `check_command` argument was not
correctly set for the calls to `broker_service_check` with the
`NEBTYPE_SERVICECHECK_PROCESSED` type.

This in turn meant that the `command_` members of the
`nebstruct_service_check_data` struct was never populated.

This is similar to the behaviour for host checks.

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>
Co-authored-by: Robert Wikman <rwikman@itrsgroup.com>