### PR TITLE
extract environment from command_line and set it directly

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -176,6 +176,18 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv, int *out_en
 			}
 			break;
 
+		case '$':
+			if(have_state(STATE_INSQ)) {
+				break;
+			}
+			/* abort checking for variables, this is something else */
+			if(have_state(STATE_INVAR))
+				env--;
+			if(have_state(STATE_INVAL))
+				env = env - 2;
+			i = len;
+			continue;
+
 		case '\'':
 			if (have_state(STATE_INDQ))
 				break;

--- a/lib/runcmd.h
+++ b/lib/runcmd.h
@@ -66,9 +66,8 @@ extern const char *runcmd_strerror(int code);
  * @param[in] cmdstring The command to launch
  * @param[out] pfd Child's stdout filedescriptor
  * @param[out] pfderr Child's stderr filedescriptor
- * @param[in] env Currently ignored for portability
  */
-extern int runcmd_open(const char *cmdstring, int *pfd, int *pfderr, char **env)
+extern int runcmd_open(const char *cmdstring, int *pfd, int *pfderr)
 	__attribute__((__nonnull__(1, 2, 3)));
 
 /**
@@ -95,7 +94,7 @@ extern int runcmd_close(int fd);
  * representing f.e. unclosed quotes, job control or output redirection.
  * See the RUNCMD_HAS_* and their ilk to find out about the flag.
  */
-extern int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv);
+extern int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv, int *out_envc, char **out_env);
 
 NAGIOS_END_DECL
 

--- a/lib/test-runcmd.c
+++ b/lib/test-runcmd.c
@@ -61,7 +61,7 @@ struct {
 	{ RUNCMD_HAS_WILDCARD, "ls -l /dev/tty?" },
 	{ 0, "ls -l /dev/tty\\?" },
 	{ RUNCMD_HAS_SHVAR, "echo $foo" },
-	{ RUNCMD_HAS_SHVAR, "VAR='foo' echo bar" },
+	{ 0, "VAR='foo' echo bar" },
 	{ 0, "echo \\$foo" },
 	{ RUNCMD_HAS_PAREN, "\\$(hoopla booyaka" },
 	{ 0, "\\$\\(hoopla booyaka" },
@@ -74,18 +74,21 @@ struct {
 	char *cmd;
 	int argc_exp;
 	char *argv_exp[10];
+	int envc_exp;
+	char *env_exp[20];
 } parse_case[] = {
-	{ 0, "foo bar nisse", 3, { "foo", "bar", "nisse", NULL }},
-	{ 0, "foo\\ bar nisse", 2, { "foo bar", "nisse", NULL }},
-	{ 0, "\"\\\\foo\"", 1, { "\\foo", NULL }},
-	{ 0, "\"\\1bs in dq\"", 1, { "\\1bs in dq", NULL }},
-	{ 0, "\"\\\\2bs in dq\"", 1, { "\\2bs in dq", NULL }},
-	{ 0, "\"\\\\\\3bs in dq\"", 1, { "\\\\3bs in dq", NULL }},
-	{ 0, "\"\\\\\\\\4bs in dq\"", 1, { "\\\\4bs in dq", NULL }},
-	{ 0, "\\ \t \\\t  \\ ", 3, { " ", "\t", " ", NULL }},
-	{ 0, "\\$foo walla wonga", 3, { "$foo", "walla", "wonga", NULL }},
-	{ 0, "\"\\$bar is\" very wide open", 4, { "$bar is", "very", "wide", "open", NULL }},
-	{ 0, NULL, 0, { NULL, NULL, NULL }},
+	{ 0, "foo bar nisse", 3, { "foo", "bar", "nisse", NULL }, 0, { NULL }},
+	{ 0, "foo\\ bar nisse", 2, { "foo bar", "nisse", NULL }, 0, { NULL }},
+	{ 0, "\"\\\\foo\"", 1, { "\\foo", NULL }, 0, { NULL }},
+	{ 0, "\"\\1bs in dq\"", 1, { "\\1bs in dq", NULL }, 0, { NULL }},
+	{ 0, "\"\\\\2bs in dq\"", 1, { "\\2bs in dq", NULL }, 0, { NULL }},
+	{ 0, "\"\\\\\\3bs in dq\"", 1, { "\\\\3bs in dq", NULL }, 0, { NULL }},
+	{ 0, "\"\\\\\\\\4bs in dq\"", 1, { "\\\\4bs in dq", NULL }, 0, { NULL }},
+	{ 0, "\\ \t \\\t  \\ ", 3, { " ", "\t", " ", NULL }, 0, { NULL }},
+	{ 0, "\\$foo walla wonga", 3, { "$foo", "walla", "wonga", NULL }, 0, { NULL }},
+	{ 0, "\"\\$bar is\" very wide open", 4, { "$bar is", "very", "wide", "open", NULL }, 0, { NULL }},
+	{ 0, "TEST=123 BL_AH='BLUB' foo=\"bar bar\" EMPTY= EMPTY2='' /bin/true arg1 arg2 arg3", 4, { "/bin/true", "arg1", "arg2","arg3", NULL }, 10, { "TEST", "123", "BL_AH", "BLUB", "foo", "bar bar", "EMPTY", "", "EMPTY2", "", NULL }},
+	{ 0, NULL, 0, { NULL, NULL, NULL }, 0, { NULL }},
 };
 
 int main(int argc, char **argv)
@@ -107,7 +110,7 @@ int main(int argc, char **argv)
 				t_fail("asprintf returned failure: %s", strerror(errno));
 				continue;
 			}
-			fd = runcmd_open(cmd, pfd, pfderr, NULL);
+			fd = runcmd_open(cmd, pfd, pfderr);
 			if (read(pfd[0], out, BUF_SIZE) < 0) {
 				t_fail("read returned failure: %s", strerror(errno));
 				continue;
@@ -124,9 +127,10 @@ int main(int argc, char **argv)
 	{
 		int i;
 		for (i = 0; anomaly[i].cmd; i++) {
-			int out_argc;
+			int out_argc, out_envc;
 			char *out_argv[256];
-			int result = runcmd_cmd2strv(anomaly[i].cmd, &out_argc, out_argv);
+			char *out_env[256];
+			int result = runcmd_cmd2strv(anomaly[i].cmd, &out_argc, out_argv, &out_envc, out_env);
 			ok_int(result, anomaly[i].ret, anomaly[i].cmd);
 		}
 	}
@@ -137,14 +141,19 @@ int main(int argc, char **argv)
 	{
 		int i;
 		for (i = 0; parse_case[i].cmd; i++) {
-			int x, out_argc;
+			int x, out_argc, out_envc;
 			char *out_argv[256];
-			int result = runcmd_cmd2strv(parse_case[i].cmd, &out_argc, out_argv);
+			char *out_env[256];
+			int result = runcmd_cmd2strv(parse_case[i].cmd, &out_argc, out_argv, &out_envc, out_env);
 			out_argv[out_argc] = NULL;
 			ok_int(result, 0, parse_case[i].cmd);
 			ok_int(out_argc, parse_case[i].argc_exp, parse_case[i].cmd);
 			for (x = 0; x < parse_case[x].argc_exp && out_argv[x]; x++) {
 				ok_str(parse_case[i].argv_exp[x], out_argv[x], "argv comparison test");
+			}
+			ok_int(out_envc, parse_case[i].envc_exp, parse_case[i].cmd);
+			for (x = 0; x < parse_case[x].envc_exp; x++) {
+				ok_str(parse_case[i].env_exp[x], out_env[x], "env comparison test");
 			}
 		}
 	}

--- a/lib/test-runcmd.c
+++ b/lib/test-runcmd.c
@@ -88,6 +88,7 @@ struct {
 	{ 0, "\\$foo walla wonga", 3, { "$foo", "walla", "wonga", NULL }, 0, { NULL }},
 	{ 0, "\"\\$bar is\" very wide open", 4, { "$bar is", "very", "wide", "open", NULL }, 0, { NULL }},
 	{ 0, "TEST=123 BL_AH='BLUB' foo=\"bar bar\" EMPTY= EMPTY2='' /bin/true arg1 arg2 arg3", 4, { "/bin/true", "arg1", "arg2","arg3", NULL }, 10, { "TEST", "123", "BL_AH", "BLUB", "foo", "bar bar", "EMPTY", "", "EMPTY2", "", NULL }},
+	{ RUNCMD_HAS_SHVAR, "TEST=123 TEST2=$TEST:1 /bin/true arg1", 3, { "TEST2=$TEST:1", "/bin/true", "arg1", NULL }, 2, { "TEST", "123", NULL }},
 	{ 0, NULL, 0, { NULL, NULL, NULL }, 0, { NULL }},
 };
 
@@ -146,7 +147,7 @@ int main(int argc, char **argv)
 			char *out_env[256];
 			int result = runcmd_cmd2strv(parse_case[i].cmd, &out_argc, out_argv, &out_envc, out_env);
 			out_argv[out_argc] = NULL;
-			ok_int(result, 0, parse_case[i].cmd);
+			ok_int(result, parse_case[i].ret, parse_case[i].cmd);
 			ok_int(out_argc, parse_case[i].argc_exp, parse_case[i].cmd);
 			for (x = 0; x < parse_case[x].argc_exp && out_argv[x]; x++) {
 				ok_str(parse_case[i].argv_exp[x], out_argv[x], "argv comparison test");

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -472,7 +472,7 @@ static int start_cmd(child_process *cp)
 {
 	int pfd[2] = { -1, -1}, pfderr[2] = { -1, -1};
 
-	cp->outstd.fd = runcmd_open(cp->cmd, pfd, pfderr, NULL);
+	cp->outstd.fd = runcmd_open(cp->cmd, pfd, pfderr);
 	if (cp->outstd.fd < 0) {
 		return -1;
 	}


### PR DESCRIPTION
This PR removes exposing environment variables to the process list. The
example command line: TEST=1 FOO=BAR /bin/true
would be executed like: /bin/sh -c 'TEST=1 FOO=BAR /bin/true'
and the environement variables would be visible in ps output.

Instead we extend command line parsing and remove environment variable
definitions and put them into the environment before forking and running
the command.

Signed-off-by: Sven Nierlein <sven@nierlein.de>