### PR TITLE
naemon-core must depend on libnaemon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,18 @@ Source: naemon-core
 Section: net
 Priority: optional
 Maintainer: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
-Build-Depends: debhelper (>= 9), gperf, chrpath, help2man, libicu-dev, pkg-config,
-  libglib2.0-dev, fakeroot, autoconf, automake, libtool
+Build-Depends:
+    debhelper (>= 9),
+    gperf,
+    chrpath,
+    help2man,
+    libicu-dev,
+    pkg-config,
+    libglib2.0-dev,
+    fakeroot,
+    autoconf,
+    automake,
+    libtool
 Standards-Version: 3.7.3
 Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon-core/issues
@@ -12,11 +22,15 @@ Vcs-Git: git://github.com:naemon/naemon-core.git
 
 Package: naemon-core
 Architecture: any
-Depends: adduser,
-         coreutils (>= 4.5.3),
-         lsb-base (>= 3.0-6),
-         bsd-mailx | mailx | sendemail,
-         ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
+Depends:
+    adduser,
+    coreutils (>= 4.5.3),
+    lsb-base (>= 3.0-6),
+    bsd-mailx | mailx | sendemail,
+    libnaemon (>= ${binary:Version})
+    ${misc:Depends},
+    ${perl:Depends},
+    ${shlibs:Depends}
 Replaces: naemon-tools
 Conflicts: naemon-tools
 Recommends: nagios-plugins
@@ -46,14 +60,20 @@ Section: debug
 Priority: extra
 Depends:
     ${shlibs:Depends},
-    ${misc:Depends}
+    ${misc:Depends},
+    libnaemon (>= ${binary:Version})
 Description: contains the Naemon core with debug symbols
  Naemon is a monitoring and management system for hosts, services and
  networks.
 
 Package: naemon-dev
 Architecture: any
-Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}, libnaemon, libglib2.0-dev
+Depends:
+    ${misc:Depends},
+    ${perl:Depends},
+    ${shlibs:Depends},
+    libnaemon (>= ${binary:Version}),
+    libglib2.0-dev
 Description: This package contains the header files, static libraries and development
  documentation for Naemon. If you are a NEB-module author or wish to
  write addons for Naemon using Naemons own APIs, you should install
@@ -62,7 +82,9 @@ Description: This package contains the header files, static libraries and develo
 Package: libnaemon
 Section: libs
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends:
+    ${misc:Depends},
+    ${shlibs:Depends}
 Description: Library for Naemon - common data files
  libnaemon contains the shared library for building NEB modules or addons for
  Naemon.


### PR DESCRIPTION
which is the case for rpms already. And while on it, line up dependencies.