### PR TITLE
pass commands containing tilde to shell

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -324,6 +324,11 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv, int *out_en
 				add_ret(RUNCMD_HAS_REDIR);
 			}
 			break;
+		case '~':
+			if (!have_state(STATE_INSQ)) {
+				add_ret(RUNCMD_HAS_SHVAR);
+			}
+			break;
 		case '&': case ';':
 			if (!in_quotes) {
 				set_state(STATE_SPECIAL);

--- a/lib/test-runcmd.c
+++ b/lib/test-runcmd.c
@@ -61,6 +61,7 @@ struct {
 	{ RUNCMD_HAS_WILDCARD, "ls -l /dev/tty?" },
 	{ 0, "ls -l /dev/tty\\?" },
 	{ RUNCMD_HAS_SHVAR, "echo $foo" },
+	{ RUNCMD_HAS_SHVAR, "~/test" },
 	{ 0, "VAR='foo' echo bar" },
 	{ 0, "echo \\$foo" },
 	{ RUNCMD_HAS_PAREN, "\\$(hoopla booyaka" },


### PR DESCRIPTION
Commands containing a tilde ~ should be passed to the shell. execvp does not expand it.

Signed-off-by: Sven Nierlein <sven@nierlein.de>