### PR TITLE
Cast time_t variables so tests run on Debian

### DIFF
--- a/tests/test-check-scheduling.c
+++ b/tests/test-check-scheduling.c
@@ -156,7 +156,7 @@ START_TEST(service_retry_interval_soft_non_OK_states)
 	handle_async_service_check_result(svc, &cr);
 	actual_time_left = get_timed_event_time_left_ms(svc->next_check_event);
 	expected_time_left = get_service_retry_interval_s(svc) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -195,7 +195,7 @@ START_TEST(service_check_interval_hard_non_OK_states)
 
 	actual_time_left = get_timed_event_time_left_ms(svc->next_check_event);
 	expected_time_left = get_service_check_interval_s(svc) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -233,7 +233,7 @@ START_TEST(service_check_interval_OK_states)
 
 	actual_time_left = get_timed_event_time_left_ms(svc->next_check_event);
 	expected_time_left = get_service_check_interval_s(svc) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -269,7 +269,7 @@ START_TEST(host_retry_interval_soft_non_OK_states)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = get_host_retry_interval_s(hst) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -308,7 +308,7 @@ START_TEST(host_check_interval_hard_non_OK_states)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = get_host_check_interval_s(hst) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -347,7 +347,7 @@ START_TEST(host_check_interval_OK_states)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = get_host_check_interval_s(hst) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -440,7 +440,7 @@ START_TEST(ondemand_host_check_on_service_hard_crit)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = get_host_retry_interval_s(hst) * 1000;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -491,7 +491,7 @@ START_TEST(ondemand_host_check_on_service_first_soft_crit)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = 0;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -542,7 +542,7 @@ START_TEST(ondemand_host_check_on_service_second_soft_crit)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = 0;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 }
 END_TEST
 
@@ -593,7 +593,7 @@ START_TEST(ondemand_host_check_on_service_soft_to_hard_crit)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = 0;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 	ck_assert_int_eq(HARD_STATE, svc->state_type);
 }
 END_TEST
@@ -645,7 +645,7 @@ START_TEST(ondemand_host_check_on_service_soft_ok_to_hard_ok)
 
 	actual_time_left = get_timed_event_time_left_ms(hst->next_check_event);
 	expected_time_left = 0;
-	assert_approximately_equal(expected_time_left, actual_time_left, APPROXIMATION_TOLERANCE_MS);
+	assert_approximately_equal(expected_time_left, actual_time_left, (long int)APPROXIMATION_TOLERANCE_MS);
 	ck_assert_int_eq(HARD_STATE, svc->state_type);
 }
 END_TEST

--- a/tests/test-event-heap.c
+++ b/tests/test-event-heap.c
@@ -242,7 +242,7 @@ START_TEST(event_polling_scheduling_past)
 	*user_data = _i;
 	ck_assert(schedule_event(runnable_delays[_i], test_event_callback, user_data) != NULL);
 	ck_assert_int_eq(0, event_poll_full(iobs, EVENT_MAX_POLL_TIME_MS));
-	ck_assert_msg(cb_props_param != NULL, "Event scheduled with delay %llu was never executed", runnable_delays[_i]);
+	ck_assert_msg(cb_props_param != NULL, "Event scheduled with delay %llu was never executed", (long long int)runnable_delays[_i]);
 	ck_assert_int_eq(*(int *)user_data, *(int *)(cb_props_param->user_data));
 	free(user_data);
 }
@@ -253,7 +253,7 @@ START_TEST(event_polling_scheduling_future)
 	time_t delay = (EVENT_MAX_POLL_TIME_MS / 1000) + unrunnable_delays[_i];
 	ck_assert(schedule_event(delay, test_event_callback, NULL) != NULL);
 	ck_assert_int_eq(0, event_poll_full(iobs, 10));
-	ck_assert_msg(cb_props_param == NULL, "Event scheduled with delay %llu was executed even though it's in the future", delay);
+	ck_assert_msg(cb_props_param == NULL, "Event scheduled with delay %llu was executed even though it's in the future", (long long int)delay);
 }
 END_TEST
 


### PR DESCRIPTION
While running the tests on Debian, they were failing due to an incompatibility on the size of time_t and the format that was being used when printing the messages in the tests. 

Casting the variables fixed the tests on Debian. After the changes, I ran the tests inside a Ubuntu 20.04 container to make sure they didn't break and everything was fine. 