### PR TITLE
configtest_exit_code_fix

### DIFF
--- a/debian/naemon-core.naemon.init
+++ b/debian/naemon-core.naemon.init
@@ -203,6 +203,7 @@ case "$1" in
           /bin/su - -s /bin/sh $user -c "$corelimit >/dev/null 2>&1 ; $exec -v $config"
         fi
         retval=$?
+        exit $retval
         ;;
     *)
         echo "Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload|configtest}"


### PR DESCRIPTION
Sets nonzero exit code status when config test fails.