### PR TITLE
Fix memory leak in cmd parser

### DIFF
--- a/lib/iobroker.c
+++ b/lib/iobroker.c
@@ -140,6 +140,10 @@ struct iobroker_set *iobroker_create(void)
 	}
 
 	iobs->max_fds = iobroker_max_usable_fds();
+	/* add sane max limit, if ulimit is set to unlimited or a very high value we
+	 * don't want to waste memory for nothing */
+	if (iobs->max_fds > MAX_FD_LIMIT)
+		iobs->max_fds = MAX_FD_LIMIT;
 	iobs->iobroker_fds = calloc(iobs->max_fds, sizeof(iobroker_fd *));
 	if (!iobs->iobroker_fds) {
 		goto error_out;

--- a/lib/lnae-utils.h
+++ b/lib/lnae-utils.h
@@ -88,6 +88,11 @@
 # define veclen ARRAY_SIZE
 #endif
 
+/* sets a limit for max open files if ulimit is set to unlimited or a unusual high value */
+#ifndef MAX_FD_LIMIT
+#define MAX_FD_LIMIT 100000
+#endif
+
 #ifndef offsetof
 /** standard offsetof macro */
 # define offsetof(t, f) ((unsigned long)&((t *)0)->f)

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -69,7 +69,6 @@ static int maxfd = 0;
 # endif /* _SC_OPEN_MAX */
 #endif /* OPEN_MAX */
 
-
 const char *runcmd_strerror(int code)
 {
 	switch (code) {
@@ -423,6 +422,11 @@ void runcmd_init(void)
 		}
 	}
 #endif
+
+	/* add sane max limit, if ulimit is set to unlimited or a very high value we
+	 * don't want to waste memory for nothing */
+	if (maxfd > MAX_FD_LIMIT)
+		maxfd = MAX_FD_LIMIT;
 
 	/* reset pipe handling so child processes can use shell pipes */
 	signal(SIGPIPE, SIG_DFL);

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -140,6 +140,7 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv, int *out_en
 	len = strlen(str);
 	envz = malloc(len + 1);
 	*out_envc = env;
+	out_env[0] = envz;
 	for (i = 0; i < len && continue_env_parsing; i++) {
 		const char *p = &str[i];
 
@@ -472,6 +473,8 @@ int runcmd_open(const char *cmd, int *pfd, int *pfderr)
 		argv[2] = strdup(cmd);
 		if (!argv[2]) {
 			free(argv);
+			free(env[0]);
+			free(env);
 			return RUNCMD_EALLOC;
 		}
 		argv[3] = NULL;
@@ -549,6 +552,8 @@ int runcmd_open(const char *cmd, int *pfd, int *pfderr)
 			free(argv[0]);
 		else
 			free(argv[2]);
+		free(env[0]);
+		free(env);
 		_exit(errno);
 	}
 
@@ -565,6 +570,7 @@ int runcmd_open(const char *cmd, int *pfd, int *pfderr)
 	else
 		free(argv[2]);
 	free(argv);
+	free(env[0]);
 	free(env);
 
 	/* tag our file's entry in the pid-list and return it */


### PR DESCRIPTION
Fixing two issues here. If you like separate PRs, just tell me :-)

First one fixes a memory leak in the cmd parser which makes the worker processes grow which
then leads to more cpu usage during all the forking (along with the wasted memory)

The second came to my attention while searching the leak, those two allocations where by far the biggest ones on my test system and both simply depend on the maximum number of open files.
I added a high enough max value to be hopefully future proof without wasting useless memory.
I don't think any naemon worker will ever sanely use more than 100k open file handles. I 
considered adding a log entry or another warning. But at that point, there is no access to the log and stderr/stdout is already closed.
With those patches, memory consumtion seems stable.