### PR TITLE
rpm: fix fg: no job control

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -268,7 +268,9 @@ case "$*" in
           %{_localstatedir}/log/naemon/naemon.log \
           %{_localstatedir}/log/naemon/archives
     rm -rf /var/run/naemon
-    %{insserv_cleanup}
+    %if 0%{?insserv_cleanup}
+      %{insserv_cleanup}
+    %endif
     chkconfig --del naemon >/dev/null 2>&1 || :
     systemctl try-restart naemon.service >/dev/null 2>&1 || :
     rm -rf %{_libdir}/naemon/.local


### PR DESCRIPTION
using an undefined macro trys to run literal %{insserv_cleanup} as shell command which results in the errors like

    /var/tmp/rpm-tmp.1P1HM5: line 12: fg: no job control