### PR TITLE
Rework comment handling

### DIFF
--- a/src/naemon/broker.h
+++ b/src/naemon/broker.h
@@ -137,7 +137,7 @@
 /****** EVENT FLAGS ************************/
 
 #define NEBFLAG_NONE                          0
-#define NEBFLAG_PROCESS_INITIATED             1         /* event was initiated by Nagios process */
+#define NEBFLAG_PROCESS_INITIATED             1         /* event was initiated by Naemon process */
 #define NEBFLAG_USER_INITIATED                2         /* event was initiated by a user request */
 #define NEBFLAG_MODULE_INITIATED              3         /* event was initiated by an event broker module */
 

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -1848,7 +1848,7 @@ static int host_command_handler(const struct external_command *ext_command, time
 		}
 		return OK;
 	case CMD_DEL_ALL_HOST_COMMENTS:
-		return delete_all_host_comments(target_host->name);
+		return delete_all_host_comments(target_host);
 	case CMD_ENABLE_HOST_NOTIFICATIONS:
 		enable_host_notifications(target_host);
 		return OK;
@@ -2251,7 +2251,7 @@ static int service_command_handler(const struct external_command *ext_command, t
 		target_service->next_notification = GV_TIMESTAMP("notification_time");
 		return OK;
 	case CMD_DEL_ALL_SVC_COMMENTS:
-		return delete_all_comments(SERVICE_COMMENT, target_service->host_name, target_service->description);
+		return delete_all_service_comments(target_service);
 	case CMD_ENABLE_SVC_NOTIFICATIONS:
 		enable_service_notifications(target_service);
 		return OK;

--- a/src/naemon/comments.h
+++ b/src/naemon/comments.h
@@ -26,11 +26,6 @@
 #define FLAPPING_COMMENT                3
 #define ACKNOWLEDGEMENT_COMMENT         4
 
-
-/*************************** CHAINED HASH LIMITS ***************************/
-#define COMMENT_HASHSLOTS      1024
-
-
 /**************************** DATA STRUCTURES ******************************/
 
 NAGIOS_BEGIN_DECL
@@ -49,13 +44,12 @@ typedef struct comment {
 	char 	*service_description;
 	char 	*author;
 	char 	*comment_data;
+	struct 	comment *prev;
 	struct 	comment *next;
-	struct 	comment *nexthash;
 } comment;
 
 extern struct comment *comment_list;
 
-int initialize_comment_hashmap(void);
 int initialize_comment_data(void);                                /* initializes comment data */
 int add_new_comment(int, int, char *, char *, time_t, char *, char *, int, int, int, time_t, unsigned long *); /* adds a new host or service comment */
 int add_new_host_comment(int, char *, time_t, char *, char *, int, int, int, time_t, unsigned long *);    /* adds a new host comment */
@@ -63,28 +57,22 @@ int add_new_service_comment(int, char *, char *, time_t, char *, char *, int, in
 int delete_comment(int, unsigned long);                             /* deletes a host or service comment */
 int delete_host_comment(unsigned long);                             /* deletes a host comment */
 int delete_service_comment(unsigned long);                          /* deletes a service comment */
-int delete_all_comments(int, char *, char *);                       /* deletes all comments for a particular host or service */
-int delete_all_host_comments(char *);                               /* deletes all comments for a specific host */
+int delete_all_host_comments(struct host *);                               /* deletes all comments for a specific host */
 int delete_host_acknowledgement_comments(struct host *);                   /* deletes all non-persistent ack comments for a specific host */
-int delete_all_service_comments(char *, char *);                    /* deletes all comments for a specific service */
+int delete_all_service_comments(struct service *);                    /* deletes all comments for a specific service */
 int delete_service_acknowledgement_comments(struct service *);             /* deletes all non-persistent ack comments for a specific service */
 
 struct comment *find_comment(unsigned long, int);                            /* finds a specific comment */
 struct comment *find_service_comment(unsigned long);                         /* finds a specific service comment */
 struct comment *find_host_comment(unsigned long);                            /* finds a specific host comment */
 
-struct comment *get_first_comment_by_host(char *);
-struct comment *get_next_comment_by_host(char *, struct comment *);
-
-int number_of_host_comments(char *);			              /* returns the number of comments associated with a particular host */
-int number_of_service_comments(char *, char *);		              /* returns the number of comments associated with a particular service */
+int number_of_host_comments(char *);                                         /* returns the number of comments associated with a particular host */
+int number_of_service_comments(char *, char *);                              /* returns the number of comments associated with a particular service */
 
 int add_comment(int, int, char *, char *, time_t, char *, char *, unsigned long, int, int, time_t, int); /* adds a comment (host or service) */
 int sort_comments(void);
 int add_host_comment(int, char *, time_t, char *, char *, unsigned long, int, int, time_t, int);   /* adds a host comment */
 int add_service_comment(int, char *, char *, time_t, char *, char *, unsigned long, int, int, time_t, int); /* adds a service comment */
-
-int add_comment_to_hashlist(struct comment *);
 
 void free_comment_data(void);                                             /* frees memory allocated to the comment list */
 

--- a/src/naemon/comments.h
+++ b/src/naemon/comments.h
@@ -55,6 +55,7 @@ typedef struct comment {
 
 extern struct comment *comment_list;
 
+int initialize_comment_hashmap(void);
 int initialize_comment_data(void);                                /* initializes comment data */
 int add_new_comment(int, int, char *, char *, time_t, char *, char *, int, int, int, time_t, unsigned long *); /* adds a new host or service comment */
 int add_new_host_comment(int, char *, time_t, char *, char *, int, int, int, time_t, unsigned long *);    /* adds a new host comment */

--- a/src/naemon/downtime.c
+++ b/src/naemon/downtime.c
@@ -488,9 +488,9 @@ int register_downtime(int type, unsigned long downtime_id)
 	/* add a non-persistent comment to the host or service regarding the scheduled outage */
 	if (find_comment(temp_downtime->comment_id, HOST_COMMENT | SERVICE_COMMENT) == NULL) {
 		if (temp_downtime->type == SERVICE_DOWNTIME)
-			add_new_comment(SERVICE_COMMENT, DOWNTIME_COMMENT, svc->host_name, svc->description, time(NULL), (NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
+			add_new_comment(SERVICE_COMMENT, DOWNTIME_COMMENT, svc->host_name, svc->description, time(NULL), (NULL == temp_downtime->author ? "(Naemon Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
 		else
-			add_new_comment(HOST_COMMENT, DOWNTIME_COMMENT, hst->name, NULL, time(NULL), (NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
+			add_new_comment(HOST_COMMENT, DOWNTIME_COMMENT, hst->name, NULL, time(NULL), (NULL == temp_downtime->author ? "(Naemon Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
 	}
 
 	nm_free(temp_buffer);
@@ -1309,7 +1309,8 @@ void free_downtime_data(void)
 	scheduled_downtime *this_downtime = NULL;
 	scheduled_downtime *next_downtime = NULL;
 
-	g_hash_table_destroy(dt_hashtable);
+	if(dt_hashtable != NULL)
+		g_hash_table_destroy(dt_hashtable);
 	dt_hashtable = NULL;
 
 	/* free memory for the scheduled_downtime list */

--- a/src/naemon/downtime.h
+++ b/src/naemon/downtime.h
@@ -30,7 +30,6 @@ typedef struct scheduled_downtime {
 	char *comment;
 	unsigned long comment_id;
 	int start_flex_downtime;
-	int incremented_pending_downtime; /* UNUSED */
 	struct scheduled_downtime *next;
 	struct timed_event *start_event, *stop_event;
 	struct scheduled_downtime *prev;

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -638,20 +638,19 @@ int main(int argc, char **argv)
 		initialize_downtime_data();
 		timing_point("Initialized downtime data\n");
 
+		/* initialize comment data */
+		timing_point("Initializing comment data\n");
+		initialize_comment_data();
+		timing_point("Initialized comment data\n");
+
 		/* read initial service and host state information  */
 		timing_point("Initializing retention data\n");
 		initialize_retention_data();
 		timing_point("Initialized retention data\n");
 
 		timing_point("Reading initial state information\n");
-		initialize_comment_hashmap();
 		read_initial_state_information();
 		timing_point("Read initial state information\n");
-
-		/* initialize comment data */
-		timing_point("Initializing comment data\n");
-		initialize_comment_data();
-		timing_point("Initialized comment data\n");
 
 		/* initialize performance data */
 		timing_point("Initializing performance data\n");

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -644,6 +644,7 @@ int main(int argc, char **argv)
 		timing_point("Initialized retention data\n");
 
 		timing_point("Reading initial state information\n");
+		initialize_comment_hashmap();
 		read_initial_state_information();
 		timing_point("Read initial state information\n");
 

--- a/src/naemon/nebmodules.h
+++ b/src/naemon/nebmodules.h
@@ -10,7 +10,7 @@ NAGIOS_BEGIN_DECL
 
 /***** MODULE VERSION INFORMATION *****/
 #define NEB_API_VERSION(x) int __neb_api_version = x;
-#define CURRENT_NEB_API_VERSION    5
+#define CURRENT_NEB_API_VERSION    6
 
 
 /***** MODULE INFORMATION *****/

--- a/src/naemon/objectlist.c
+++ b/src/naemon/objectlist.c
@@ -72,6 +72,26 @@ int prepend_unique_object_to_objectlist(objectlist **list, void *object_ptr, int
 	return prepend_unique_object_to_objectlist_ptr(list, object_ptr, *comparator_helper, comparator);
 }
 
+/* remove pointer from objectlist */
+int remove_object_from_objectlist(objectlist **list, void *object_ptr) {
+	objectlist *item, *next, *prev;
+
+	if (list == NULL || object_ptr == NULL)
+		return ERROR;
+
+	for (prev = NULL, item = *list; item; prev = item, item = next) {
+		next = item->next;
+		if (item->object_ptr == object_ptr) {
+			if (prev)
+				prev->next = next;
+			else
+				*list = next;
+			nm_free(item);
+			item = prev;
+		}
+	}
+	return OK;
+}
 
 /* frees memory allocated to a temporary object list */
 int free_objectlist(objectlist **temp_list)

--- a/src/naemon/objectlist.h
+++ b/src/naemon/objectlist.h
@@ -56,6 +56,15 @@ int prepend_unique_object_to_objectlist(objectlist **list, void *object_ptr, int
  * @returns OK if successful, OBJECTLIST_DUPE if the element was already in the list, ERROR otherwise.
  */
 int prepend_unique_object_to_objectlist_ptr(objectlist **list, void *object_ptr, int (*comparator)(const void *a, const void *b, void *user_data), void *user_data);
+
+/**
+ * Remove first matching object_ptr from the list.
+ * @param list An reference to an objectlist. Note that an empty objectlist is just NULL.
+ * @param object_ptr The object you want to remove from the list.
+ * @returns OK if successful, ERROR otherwise.
+ */
+int remove_object_from_objectlist(objectlist **list, void *object_ptr);
+
 /**
  * Free all the allocated memory of the objectlist. Note: this will completely
  * orphan any allocated memory inside the objectlist.

--- a/src/naemon/objects_host.c
+++ b/src/naemon/objects_host.c
@@ -310,6 +310,7 @@ void destroy_host(host *this_host)
 	nm_free(this_host->plugin_output);
 	nm_free(this_host->long_plugin_output);
 	nm_free(this_host->perf_data);
+	free_objectlist(&this_host->comments_list);
 	free_objectlist(&this_host->hostgroups_ptr);
 	free_objectlist(&this_host->notify_deps);
 	free_objectlist(&this_host->exec_deps);

--- a/src/naemon/objects_host.h
+++ b/src/naemon/objects_host.h
@@ -119,6 +119,7 @@ struct host {
 	time_t  last_state_history_update;
 	int     is_flapping;
 	unsigned long flapping_comment_id;
+	struct objectlist *comments_list;
 	double  percent_state_change;
 	int     total_services;
 	unsigned long modified_attributes;

--- a/src/naemon/objects_service.c
+++ b/src/naemon/objects_service.c
@@ -326,6 +326,7 @@ void destroy_service(service *this_service, int truncate_lists)
 	nm_free(this_service->long_plugin_output);
 	nm_free(this_service->perf_data);
 	nm_free(this_service->event_handler_args);
+	free_objectlist(&this_service->comments_list);
 	free_objectlist(&this_service->servicegroups_ptr);
 	free_objectlist(&this_service->notify_deps);
 	free_objectlist(&this_service->exec_deps);

--- a/src/naemon/objects_service.h
+++ b/src/naemon/objects_service.h
@@ -110,6 +110,7 @@ struct service {
 	int     state_history_index;
 	int     is_flapping;
 	unsigned long flapping_comment_id;
+	struct objectlist *comments_list;
 	double  percent_state_change;
 	unsigned long modified_attributes;
 	struct host *host_ptr;

--- a/src/naemon/shared.c
+++ b/src/naemon/shared.c
@@ -413,30 +413,6 @@ void strip(char *buffer)
 }
 
 
-/**************************************************
- *************** HASH FUNCTIONS *******************
- **************************************************/
-/* dual hash function */
-int hashfunc(const char *name1, const char *name2, int hashslots)
-{
-	unsigned int i, result;
-
-	result = 0;
-
-	if (name1)
-		for (i = 0; i < strlen(name1); i++)
-			result += name1[i];
-
-	if (name2)
-		for (i = 0; i < strlen(name2); i++)
-			result += name2[i];
-
-	result = result % hashslots;
-
-	return result;
-}
-
-
 /*
  * given a date/time in time_t format, produce a corresponding
  * date/time string, including timezone

--- a/src/naemon/shared.h
+++ b/src/naemon/shared.h
@@ -48,7 +48,6 @@ int mmap_fclose(mmapfile *temp_mmapfile);
 char *mmap_fgets(mmapfile *temp_mmapfile);
 char *mmap_fgets_multiline(mmapfile * temp_mmapfile);
 void strip(char *buffer);
-int hashfunc(const char *name1, const char *name2, int hashslots);
 void get_datetime_string(time_t *raw_time, char *buffer,
                                 int buffer_length, int type);
 void get_time_breakdown(unsigned long raw_time, int *days, int *hours,

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -9,6 +9,7 @@
 #include "objects_servicedependency.h"
 #include "statusdata.h"
 #include "comments.h"
+#include "downtime.h"
 #include "macros.h"
 #include "broker.h"
 #include "nebmods.h"
@@ -963,6 +964,7 @@ void free_memory(nagios_macros *mac)
 	destroy_objects_servicegroup(TRUE);
 
 	free_comment_data();
+	free_downtime_data();
 
 	nm_free(global_host_event_handler);
 	nm_free(global_service_event_handler);

--- a/t-tap/smallconfig/retention.dat
+++ b/t-tap/smallconfig/retention.dat
@@ -442,7 +442,7 @@ persistent=1
 entry_time=1264451960
 expires=0
 expire_time=0
-author=(Nagios Process)
+author=(Naemon Process)
 comment_data=Notifications for this host are being suppressed because it was detected as having been flapping between different states (34.5% change > 20.0% threshold).  When the host state stabilizes and the flapping stops, notifications will be re-enabled.
 }
 servicecomment {
@@ -455,7 +455,7 @@ persistent=1
 entry_time=1264451960
 expires=0
 expire_time=0
-author=(Nagios Process)
+author=(Naemon Process)
 comment_data=Notifications for this service are being suppressed because it was detected as having been flapping between different states (40.3% change >= 20.0% threshold).  When the service state stabilizes and the flapping stops, notifications will be re-enabled.
 }
 hostcomment {

--- a/t-tap/test_config.c
+++ b/t-tap/test_config.c
@@ -85,6 +85,7 @@ int main(int argc, char **argv)
 
 	initialize_retention_data();
 	initialize_downtime_data();
+	initialize_comment_data();
 
 	ok(xrddefault_read_state_information() == OK, "Reading retention data");
 

--- a/t-tap/test_downtime.c
+++ b/t-tap/test_downtime.c
@@ -39,6 +39,7 @@ int main(int argc, char **argv)
 	time(&now);
 
 	init_event_queue();
+	initialize_comment_data();
 	initialize_downtime_data();
 	init_objects_host(4);
 	init_objects_service(8);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -12,3 +12,12 @@
 /test-utils
 /test-check-scheduling
 /test-objects
+/test-arith
+/test-arith-builtins
+/test-check-dependencies
+/test-check-result-processing
+/test-neb-callbacks
+/test-query-handler
+/test-retention
+/test-scheduled-downtimes
+/test-worker

--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -47,6 +47,7 @@ void setup(void)
 	init_objects_service(2);
 	init_objects_command(1);
 	initialize_downtime_data();
+	initialize_comment_data();
 	initialize_retention_data();
 	workdir = getcwd(NULL, 0);
 


### PR DESCRIPTION
rework comment handling
    
This PR reworks the comment handling to improve performance when having lots of comments.
    
  - it add a prev pointer to the comments list so we don't have to iterate over the complete list when removing an item
  - it replaces the hash lookup to quickly access comments for specific hosts/services in favor of a new host/service attribute which holds links to the comments
  - it avoids duplicate host/service lookups for DEL_ALL_HOST_COMMENTS/DEL_ALL_SVC_COMMENTS command
  - it removes hash functions which are now unused
    
In general, it tries to adopt the downtime handling over to comments.
    
This PR is based on and includes #375.
    
Since the internal object structure changes, all NEB modules have to be rebuild. (We therefor increase CURRENT_NEB_API_VERSION to 6)
    
Signed-off-by: Sven Nierlein <sven@consol.de>
