### PR TITLE
Fixed: Naemon stops executing checks and doesnt respawn Core Worker #419 

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,7 +9,8 @@
                 //"/usr/lib/gcc/x86_64-redhat-linux/12/include/**", // Fedora
                 "/usr/local/include/**",
                 "/usr/include/**",
-                "/usr/lib64/**"
+                "/usr/lib64/**",
+                "/usr/lib/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,13 +12,19 @@
             // This will trigger the "make all" task from tasks.json
             "preLaunchTask": "make all",
             // We are not using the binary from the build folder because we do not want to run the "make install" task.
-            // The "make install" task is only to generate the default naemon configurtion files 
+            // The "make install" task is only to generate the default naemon configurtion files
             "program": "${workspaceFolder}/src/naemon/.libs/naemon",
             "args": [
                 //"--help",
                 "${workspaceFolder}/build/etc/naemon/naemon.cfg"
             ],
             "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/.libs"
+                }
+            ],
 
             // Optional parameter. If true, the debugger should stop at the entrypoint of the target.
             "stopAtEntry": true,

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -41,6 +41,7 @@ Requires(pre): systemd
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
+BuildRequires: pkgconfig(systemd)
 %if 0%{suse_version} < 1230
 Requires(pre): pwdutils
 %else

--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -633,33 +633,35 @@ static void handle_worker_host_check(wproc_result *wpres, void *arg, int flags)
 	if (currently_running_host_checks > 0)
 		currently_running_host_checks--;
 
-	hst = find_host(cr->host_name);
-	if (hst && wpres) {
-		hst->is_executing = FALSE;
-		memcpy(&cr->rusage, &wpres->rusage, sizeof(wpres->rusage));
-		cr->start_time.tv_sec = wpres->start.tv_sec;
-		cr->start_time.tv_usec = wpres->start.tv_usec;
-		cr->finish_time.tv_sec = wpres->stop.tv_sec;
-		cr->finish_time.tv_usec = wpres->stop.tv_usec;
-		if (WIFEXITED(wpres->wait_status)) {
-			cr->return_code = WEXITSTATUS(wpres->wait_status);
-		} else {
-			cr->return_code = STATE_UNKNOWN;
-		}
+	if (wpres) {
+		hst = find_host(cr->host_name);
+		if (hst) {
+			hst->is_executing = FALSE;
+			memcpy(&cr->rusage, &wpres->rusage, sizeof(wpres->rusage));
+			cr->start_time.tv_sec = wpres->start.tv_sec;
+			cr->start_time.tv_usec = wpres->start.tv_usec;
+			cr->finish_time.tv_sec = wpres->stop.tv_sec;
+			cr->finish_time.tv_usec = wpres->stop.tv_usec;
+			if (WIFEXITED(wpres->wait_status)) {
+				cr->return_code = WEXITSTATUS(wpres->wait_status);
+			} else {
+				cr->return_code = STATE_UNKNOWN;
+			}
 
-		if (wpres->outstd && *wpres->outstd) {
-			cr->output = nm_strdup(wpres->outstd);
-		} else if (wpres->outerr && *wpres->outerr) {
-			nm_asprintf(&cr->output, "(No output on stdout) stderr: %s", wpres->outerr);
-		} else {
-			cr->output = NULL;
-		}
+			if (wpres->outstd && *wpres->outstd) {
+				cr->output = nm_strdup(wpres->outstd);
+			} else if (wpres->outerr && *wpres->outerr) {
+				nm_asprintf(&cr->output, "(No output on stdout) stderr: %s", wpres->outerr);
+			} else {
+				cr->output = NULL;
+			}
 
-		cr->early_timeout = wpres->early_timeout;
-		cr->exited_ok = wpres->exited_ok;
-		cr->engine = NULL;
-		cr->source = wpres->source;
-		process_check_result(cr);
+			cr->early_timeout = wpres->early_timeout;
+			cr->exited_ok = wpres->exited_ok;
+			cr->engine = NULL;
+			cr->source = wpres->source;
+			process_check_result(cr);
+		}
 	}
 	free_check_result(cr);
 	nm_free(cr);

--- a/src/naemon/common.h
+++ b/src/naemon/common.h
@@ -471,8 +471,6 @@ NAGIOS_END_DECL
 
 #define MAX_FILENAME_LENGTH			256	/* max length of path/filename that Nagios will process */
 #define MAX_INPUT_BUFFER			1024	/* size in bytes of max. input buffer (for reading files, misc stuff) */
-#define MAX_COMMAND_BUFFER                      8192    /* max length of raw or processed command line */
-
 #define MAX_DATETIME_LENGTH			48
 
 

--- a/src/naemon/nebmods.c
+++ b/src/naemon/nebmods.c
@@ -195,9 +195,11 @@ int neb_load_module(nebmodule *mod)
 
 	/* check the module API version */
 	if (module_version_ptr == NULL || ((*module_version_ptr) != CURRENT_NEB_API_VERSION)) {
-
-		nm_log(NSLOG_RUNTIME_ERROR, "Error: Module '%s' is using an old or unspecified version of the event broker API.  Module will be unloaded.\n", mod->filename);
-
+		if (module_version_ptr == NULL) {
+			nm_log(NSLOG_RUNTIME_ERROR, "Error: Module '%s' did not specify a version of the event broker API. Module will be unloaded.\n", mod->filename);
+		} else {
+			nm_log(NSLOG_RUNTIME_ERROR, "Error: Module '%s' is using an incompatible version (v%d) of the event broker API (current version: v%d). Module will be unloaded.\n", mod->filename, *module_version_ptr, CURRENT_NEB_API_VERSION);
+		}
 		neb_unload_module(mod, NEBMODULE_FORCE_UNLOAD, NEBMODULE_ERROR_API_VERSION);
 
 		return ERROR;

--- a/src/naemon/objects.c
+++ b/src/naemon/objects.c
@@ -11,6 +11,7 @@
 #include "logging.h"
 #include "globals.h"
 #include "nm_alloc.h"
+#include "utils.h"
 
 int __nagios_object_structure_version = CURRENT_OBJECT_STRUCTURE_VERSION;
 
@@ -20,6 +21,9 @@ int fcache_objects(char *cache_file)
 	FILE *fp = NULL;
 	time_t current_time = 0L;
 	unsigned int i;
+	char *tmp_file = NULL;
+	int fd = 0;
+	int result = OK;
 
 	/* some people won't want to cache their objects */
 	if (!cache_file || !strcmp(cache_file, "/dev/null"))
@@ -27,10 +31,22 @@ int fcache_objects(char *cache_file)
 
 	time(&current_time);
 
+	nm_asprintf(&tmp_file, "%sXXXXXX", cache_file);
+	if (tmp_file == NULL)
+		return ERROR;
+
+	if ((fd = mkstemp(tmp_file)) == -1) {
+		nm_log(NSLOG_RUNTIME_ERROR, "Error: Unable to create temp file '%s' for writing object cache data: %s\n", tmp_file, strerror(errno));
+		nm_free(tmp_file);
+		return ERROR;
+	}
+
 	/* open the cache file for writing */
-	fp = fopen(cache_file, "w");
+	fp = (FILE *)fopen(tmp_file, "w");
 	if (fp == NULL) {
-		nm_log(NSLOG_CONFIG_WARNING, "Warning: Could not open object cache file '%s' for writing!\n", cache_file);
+		unlink(tmp_file);
+		nm_log(NSLOG_CONFIG_WARNING, "Warning: Could not open object cache data file '%s' for writing!\n", tmp_file);
+		nm_free(tmp_file);
 		return ERROR;
 	}
 
@@ -43,7 +59,6 @@ int fcache_objects(char *cache_file)
 	fprintf(fp, "#\n");
 	fprintf(fp, "# Created: %s", ctime(&current_time));
 	fprintf(fp, "########################################\n\n");
-
 
 	/* cache timeperiods */
 	for (i = 0; i < num_objects.timeperiods; i++)
@@ -109,7 +124,41 @@ int fcache_objects(char *cache_file)
 			fcache_hostescalation(fp, esclist->object_ptr);
 	}
 
-	fclose(fp);
+	/* reset file permissions */
+	fchmod(fd, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 
-	return OK;
+	/* flush the file to disk */
+	fflush(fp);
+
+	/* fsync the file so that it is completely written out before moving it */
+	fsync(fd);
+
+	/* close the temp file */
+	result = ferror(fp) | fclose(fp);
+
+	/* save/close was successful */
+	if (result == 0) {
+
+		result = OK;
+
+		/* move the temp file to the status log (overwrite the old status log) */
+		if (my_rename(tmp_file, cache_file)) {
+			unlink(tmp_file);
+			nm_log(NSLOG_RUNTIME_ERROR, "Error: Unable to update cache data file '%s': %s", cache_file, strerror(errno));
+			result = ERROR;
+		}
+	}
+
+	/* a problem occurred saving the file */
+	else {
+		result = ERROR;
+
+		/* remove temp file and log an error */
+		unlink(tmp_file);
+		nm_log(NSLOG_RUNTIME_ERROR, "Error: Unable to save cache data file: %s", strerror(errno));
+	}
+
+	nm_free(tmp_file);
+
+	return result;
 }

--- a/src/naemon/objects.c
+++ b/src/naemon/objects.c
@@ -141,7 +141,7 @@ int fcache_objects(char *cache_file)
 
 		result = OK;
 
-		/* move the temp file to the status log (overwrite the old status log) */
+		/* move the temp file to the objects data file (overwrite the old objects.cache) */
 		if (my_rename(tmp_file, cache_file)) {
 			unlink(tmp_file);
 			nm_log(NSLOG_RUNTIME_ERROR, "Error: Unable to update cache data file '%s': %s", cache_file, strerror(errno));

--- a/src/naemon/workers.c
+++ b/src/naemon/workers.c
@@ -165,7 +165,6 @@ static void run_job_callback(struct wproc_job *job, struct wproc_result *wpres, 
 		return;
 	
 	if (!wpres) {
-		nm_log(NSLOG_RUNTIME_ERROR, "---!!!--- wpres is null or so TODO REMOVE THIS");
 		return;
 	}
 

--- a/src/naemon/workers.c
+++ b/src/naemon/workers.c
@@ -64,6 +64,9 @@ static struct wproc_list *to_remove = NULL;
 unsigned int wproc_num_workers_online = 0, wproc_num_workers_desired = 0;
 unsigned int wproc_num_workers_spawned = 0;
 
+static int get_desired_workers(int desired_workers);
+static int spawn_core_worker(void);
+
 #define tv2float(tv) ((float)((tv)->tv_sec) + ((float)(tv)->tv_usec) / 1000000.0)
 
 static void wproc_logdump_buffer(int debuglevel, int verbosity, const char *prefix, char *buf)
@@ -160,6 +163,11 @@ static void run_job_callback(struct wproc_job *job, struct wproc_result *wpres, 
 {
 	if (!job || !job->callback)
 		return;
+	
+	if (!wpres) {
+		nm_log(NSLOG_RUNTIME_ERROR, "---!!!--- wpres is null or so TODO REMOVE THIS");
+		return;
+	}
 
 	(*job->callback)(wpres, job->data, val);
 	job->callback = NULL;
@@ -414,6 +422,7 @@ static int handle_worker_result(int sd, int events, void *arg)
 	char *buf, *error_reason = NULL;
 	size_t size;
 	int ret;
+	unsigned int desired_workers;
 	struct wproc_worker *wp = (struct wproc_worker *)arg;
 
 	ret = nm_bufferqueue_read(wp->bq, wp->sd);
@@ -428,16 +437,31 @@ static int handle_worker_result(int sd, int events, void *arg)
 		nm_log(NSLOG_INFO_MESSAGE, "wproc: Socket to worker %s broken, removing", wp->name);
 		wproc_num_workers_online--;
 		iobroker_unregister(nagios_iobs, sd);
-		if (workers.len <= 0) {
-			/* there aren't global workers left, we can't run any more checks
-			 * we should try respawning a few of the standard ones
-			 */
-			nm_log(NSLOG_RUNTIME_ERROR, "wproc: All our workers are dead, we can't do anything!");
-		}
 
 		/* remove worker from worker list - this ensures that we don't reassign
 		 * its jobs back to itself*/
 		remove_worker(wp);
+
+		desired_workers = get_desired_workers(num_check_workers);
+
+		if (workers.len < desired_workers) {
+			/* there aren't global workers left, we can't run any more checks
+			 * we should try respawning a few of the standard ones
+			 */
+			nm_log(NSLOG_RUNTIME_ERROR, "wproc: We have have less Core Workers than we should have, trying to respawn Core Worker");
+
+			/* Respawn a worker */
+			if ((ret = spawn_core_worker()) < 0) {
+				nm_log(NSLOG_RUNTIME_ERROR, "wproc: Failed to respawn Core Worker");
+			} else {
+				nm_log(NSLOG_INFO_MESSAGE, "wproc: Respawning Core Worker %u was successful", ret);
+			}
+		} else if (workers.len == 0) {
+			/* there aren't global workers left, we can't run any more checks
+			 * this should never happen, because the respawning will be done in the upper if condition
+			 */
+			nm_log(NSLOG_RUNTIME_ERROR, "wproc: All our workers are dead, we can't do anything!");
+		}
 
 		/* reassign this dead worker's jobs */
 		g_hash_table_iter_init(&iter, wp->jobs);
@@ -449,7 +473,7 @@ static int handle_worker_result(int sd, int events, void *arg)
 			);
 		}
 
-		wproc_destroy(wp, 0);
+		wproc_destroy(wp, WPROC_FORCE);
 		return 0;
 	}
 	while ((buf = worker_ioc2msg(wp->bq, &size, 0))) {
@@ -664,6 +688,32 @@ static int spawn_core_worker(void)
 }
 
 
+static int get_desired_workers(int desired_workers)
+{
+	if (desired_workers <= 0) {
+		int cpus = online_cpus();
+
+		if (desired_workers < 0) {
+			desired_workers = cpus - desired_workers;
+		}
+		if (desired_workers <= 0) {
+			desired_workers = cpus * 1.5;
+			/* min 4 workers, as it's tested and known to work */
+			if (desired_workers < 4)
+				desired_workers = 4;
+			else if (desired_workers > 48) {
+				/* don't go crazy in NASA's network (1024 cores) */
+				desired_workers = 48;
+			}
+		}
+	}
+
+	wproc_num_workers_desired = desired_workers;
+
+	return desired_workers;
+}
+
+
 int init_workers(int desired_workers)
 {
 	int i;
@@ -682,24 +732,8 @@ int init_workers(int desired_workers)
 		return -1;
 	}
 
-	if (desired_workers <= 0) {
-		int cpus = online_cpus();
-
-		if (desired_workers < 0) {
-			desired_workers = cpus - desired_workers;
-		}
-		if (desired_workers <= 0) {
-			desired_workers = cpus * 1.5;
-			/* min 4 workers, as it's tested and known to work */
-			if (desired_workers < 4)
-				desired_workers = 4;
-			else if (desired_workers > 48) {
-				/* don't go crazy in NASA's network (1024 cores) */
-				desired_workers = 48;
-			}
-		}
-	}
-	wproc_num_workers_desired = desired_workers;
+	/* Get the number of workers we need */
+	desired_workers = get_desired_workers(desired_workers);
 
 	if (workers_alive() == desired_workers)
 		return 0;


### PR DESCRIPTION
While reviewing #419, I noticed that Naemon is not taking care about it's dead worker processes. Whenever a worker process dies, it will become a `<defunct>` zombie process.
The reason for this was, that Naemon did not call `waitpid()` when a worker process dies. I did not find any explanation why this was implemented this way.
Could `waitpid(wp->pid, &i, 0)` hang (wait forever), if the worker process was not forked from the currently running Naemon? We could probably replace this by `waitpid(wp->pid, &i, WNOHANG)`, but I'm not 100% sure about this.
Best I could find about this was: https://github.com/NagiosEnterprises/nagioscore/issues/635
