### PR TITLE
improve latency handling

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -140,17 +140,14 @@ static void handle_host_check_event(struct nm_event_execution_properties *evprop
 	host *hst = (host *)evprop->user_data;
 	double latency;
 	struct timeval tv;
-	struct timeval event_runtime;
 	int options = hst->check_options;
 
 	int result = OK;
 
 	if (evprop->execution_type == EVENT_EXEC_NORMAL) {
 		/* get event latency */
+		latency = evprop->attributes.timed.latency;
 		gettimeofday(&tv, NULL);
-		event_runtime.tv_sec = hst->next_check;
-		event_runtime.tv_usec = 0;
-		latency = (double)(tv_delta_f(&event_runtime, &tv));
 
 		/* When the callback is called, the pointer to the timed event is invalid */
 		hst->next_check_event = NULL;

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -143,7 +143,6 @@ static void handle_service_check_event(struct nm_event_execution_properties *evp
 	int nudge_seconds = 0;
 	double latency;
 	struct timeval tv;
-	struct timeval event_runtime;
 	int options = temp_service->check_options;
 	host *temp_host = NULL;
 
@@ -152,10 +151,8 @@ static void handle_service_check_event(struct nm_event_execution_properties *evp
 	if (evprop->execution_type == EVENT_EXEC_NORMAL) {
 
 		/* get event latency */
+		latency = evprop->attributes.timed.latency;
 		gettimeofday(&tv, NULL);
-		event_runtime.tv_sec = temp_service->next_check;
-		event_runtime.tv_usec = 0;
-		latency = (double)(tv_delta_f(&event_runtime, &tv));
 
 		/* When the callback is called, the pointer to the timed event is invalid */
 		temp_service->next_check_event = NULL;
@@ -485,6 +482,8 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 	/* was this check passive or active? */
 	temp_service->check_type = (queued_check_result->check_type == CHECK_TYPE_ACTIVE) ? CHECK_TYPE_ACTIVE : CHECK_TYPE_PASSIVE;
+
+	temp_service->latency = queued_check_result->latency;
 
 	/* update check statistics for passive checks */
 	if (queued_check_result->check_type == CHECK_TYPE_PASSIVE)


### PR DESCRIPTION
right now all hosts/services have a wrong latency because calculation is based on the integer value of next_check but the scheduled event uses microseconds. So use the latency based on the event timestamp instead which has subsecond precision.