### PR TITLE
fix unversioned obsoletes

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -11,7 +11,6 @@ Packager: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
 Vendor: Naemon Core Development Team
 Source0: naemon-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
-Obsoletes: naemon-tools
 BuildRequires: gperf
 BuildRequires: logrotate
 BuildRequires: autoconf


### PR DESCRIPTION
this is a old relict from very early rpms, time to let it go.

```
RPM build warnings:
line 14: It's not recommended to have unversioned Obsoletes: Obsoletes: naemon-tools
```