### PR TITLE
fix Werror=nonnull in close_command_file

### DIFF
--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -183,7 +183,8 @@ int close_command_file(void)
 	command_file_created = FALSE;
 
 	/* close the command file */
-	fclose(command_file_fp);
+	if (command_file_fp != NULL)
+		fclose(command_file_fp);
 
 	return OK;
 }


### PR DESCRIPTION
add check if fp is not NULL because of:

```
[   92s] In function 'close_command_file',
[   92s]     inlined from 'close_command_file' at src/naemon/commands.c:171:5:
[   92s] src/naemon/commands.c:186:9: error: argument 1 null where non-null expected [-Werror=nonnull]
[   92s]   186 |         fclose(command_file_fp);
[   92s]       |         ^~~~~~~~~~~~~~~~~~~~~~~
[   92s] In file included from src/naemon/objects_host.h:8,
[   92s]                  from src/naemon/comments.h:9,
[   92s]                  from src/naemon/commands.c:3:
[   92s] /usr/include/stdio.h: In function 'close_command_file':
[   92s] /usr/include/stdio.h:183:12: note: in a call to function 'fclose' declared 'nonnull'
[   92s]   183 | extern int fclose (FILE *__stream) __nonnull ((1));
[   92s]       |            ^~~~~~
[   93s] cc1: all warnings being treated as errors
```