### PR TITLE
use dynamic sized command line buffer

### DIFF
--- a/src/naemon/common.h
+++ b/src/naemon/common.h
@@ -471,8 +471,6 @@ NAGIOS_END_DECL
 
 #define MAX_FILENAME_LENGTH			256	/* max length of path/filename that Nagios will process */
 #define MAX_INPUT_BUFFER			1024	/* size in bytes of max. input buffer (for reading files, misc stuff) */
-#define MAX_COMMAND_BUFFER                      8192    /* max length of raw or processed command line */
-
 #define MAX_DATETIME_LENGTH			48
 
 


### PR DESCRIPTION
Previously we used a fixed size 8k buffer when parsing command line arguments. This sounds much, but there are command lines bigger than 8k and they are simply cut off without any warning.

Instead we use a dynamic sized buffer with the size of the raw command now.

(while on it, fixing the crazy indent)