### PR TITLE
add systemd to build requires

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -41,6 +41,7 @@ Requires(pre): systemd
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
+BuildRequires: pkgconfig(systemd)
 %if 0%{suse_version} < 1230
 Requires(pre): pwdutils
 %else


### PR DESCRIPTION
this (should) fix this build error on obs:
```
[  139s] /.build_patchrpmcheck_scr: line 55: systemd-tmpfiles: command not found
[  139s] postinstall script of naemon-core-1.4.1-lp154.18.1.x86_64.rpm failed
```