### PR TITLE
release 1.4.2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,18 @@
+1.4.2 - Jan 03 2024
+===================
+Features:
+* remove size limit on external command argument length
+* performance improvements when having lots of comments
+
+Changed:
+* write objects.precache into a tmp file first
+* increased CURRENT_NEB_API_VERSION to 6 (neb modules need to be rebuild)
+
+Bugfixes:
+* fix build error on fedora
+* fix latency calculation having negative value sometimes
+
+
 1.4.1 - Feb 01 2023
 ===================
 Features:

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@
 Features:
 * remove size limit on external command argument length
 * performance improvements when having lots of comments
-* Respawn dead core worker
+* respawn dead core worker
 
 Changed:
 * write objects.precache into a tmp file first

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
 Features:
 * remove size limit on external command argument length
 * performance improvements when having lots of comments
+* Respawn dead core worker
 
 Changed:
 * write objects.precache into a tmp file first

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+naemon-core (1.4.2) UNRELEASED; urgency=low
+
+  * new upstream release
+
+ -- Naemon Development Team <naemon-dev@monitoring-lists.org>  Fri, 29 Dec 2023 14:00:04 +0100
+
 naemon-core (1.4.1) UNRELEASED; urgency=low
 
   * new upstream release

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -2,7 +2,7 @@
 
 Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon-core
-Version: 1.4.1
+Version: 1.4.2
 Release: 0
 License: GPL-2.0-only
 Group: Applications/System

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.4.1
+VERSION=1.4.2
 if test -e .git; then
     if hash git 2>/dev/null; then
         VERSION=$(git describe --tag --exact-match 2>/dev/null | sed -e 's/^v//')


### PR DESCRIPTION
I'd say it's about time for a new releae:

```
1.4.2 - Jan 03 2024
===================
Features:
* remove size limit on external command argument length
* performance improvements when having lots of comments
* respawn dead core worker

Changed:
* write objects.precache into a tmp file first
* increased CURRENT_NEB_API_VERSION to 6 (neb modules need to be rebuild)

Bugfixes:
* fix build error on fedora
* fix latency calculation having negative value sometimes
```