### PR TITLE
Define ETIME for systems without that constant

### DIFF
--- a/src/naemon/workers.h
+++ b/src/naemon/workers.h
@@ -12,6 +12,10 @@
 
 #define WPROC_FORCE  (1 << 0)
 
+#ifndef ETIME
+#define ETIME ETIMEDOUT
+#endif
+
 NAGIOS_BEGIN_DECL
 
 typedef struct wproc_result {


### PR DESCRIPTION
ETIME alternative implementation as ETIMEDOUT is already available for the worker component, but not for the naemon component.

This fixes the following compilation error on systems without ETIME:

```
src/naemon/workers.c:517:27: error: use of undeclared identifier 'ETIME'
                if (wpres.error_code == ETIME) {
                                        ^
1 error generated.
```

This has been noticed on FreeBSD.