### PR TITLE
Include <sys/wait.h> for wait constants

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -21,6 +21,7 @@
 #include "objects_hostdependency.h"
 #include <string.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 
 #include "neberrors.h"
 

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -22,6 +22,7 @@
 #include "objects_servicedependency.h"
 #include <string.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 #include "neberrors.h"
 
 /* Scheduling (before worker job is started) */

--- a/src/naemon/notifications.c
+++ b/src/naemon/notifications.c
@@ -16,6 +16,7 @@
 #include "nm_alloc.h"
 #include <string.h>
 #include <sys/time.h>
+#include <sys/wait.h>
 
 struct notification_job {
 	host *hst;


### PR DESCRIPTION
Constants like WIFEXITED are defined in sys/wait.h header.

This fixes a compilation issue on FreeBSD where those contants aren't implicitly made available without an explicit include of those.