### PR TITLE
initialize hosts last_state_change and last_hard_state_change

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -1065,6 +1065,12 @@ static int handle_host_state(host *hst, int *alert_recorded)
 		}
 	}
 
+	/* initialize the last host state change times if necessary */
+	if (hst->last_state_change == (time_t)0)
+		hst->last_state_change = hst->last_check;
+	if (hst->last_hard_state_change == (time_t)0)
+		hst->last_hard_state_change = hst->last_check;
+
 	return OK;
 }
 


### PR DESCRIPTION
Currently the hosts last_state_change and last_hard_state_change will only be initialized if the state changes or in check_service.c when the first service result arives. I see no reason why this shouldn't be done for host results as well.