### PR TITLE
fix(rpm): Delay Naemon restart until posttrans

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -195,16 +195,8 @@ fi
 %post
 case "$*" in
   2)
-    # Upgrading so try and restart if already running
-    # For systemctl systems we need to reload the configs
-    # becaues it'll complain if we just installed a new
-    # init script
-    %if %{?_unitdir:1}0
-      systemctl daemon-reload &>/dev/null || true
-      systemctl condrestart naemon.service &>/dev/null || true
-    %else
-      /etc/init.d/naemon condrestart &>/dev/null || true
-    %endif
+    # Upgrade, don't do anything
+    # Restarts are handled in posttrans
   ;;
   1)
     # install example conf.d only once on the first installation
@@ -284,6 +276,18 @@ case "$*" in
   *) echo case "$*" not handled in postun
 esac
 exit 0
+
+%posttrans
+# try and restart if already running
+# For systemctl systems we need to reload the configs
+# because it'll complain if we just installed a new
+# init script
+%if %{?_unitdir:1}0
+  systemctl daemon-reload &>/dev/null || true
+  systemctl condrestart naemon.service &>/dev/null || true
+%else
+  /etc/init.d/naemon condrestart &>/dev/null || true
+%endif
 
 
 


### PR DESCRIPTION
The posttrans scriptlet executes after the RPM transaction has concluded, i.e. when all packages have been installed or upgraded. Delaying the Naemon restart until posttrans prevents API compatibility issues when naemon-core upgrades before naemon-livestatus. See https://github.com/naemon/naemon-core/issues/454.

Note that it is not possible to infer the RPM operation (install or upgrade) from the posttrans scriptlet argument, since they are the same: https://en.opensuse.org/openSUSE:Packaging_scriptlet_snippets#Syntax This should not cause any problems since the scriptlet only restarts Naemon if it was already running. In other words, it won't cause Naemon to start immediately after installation.