### PR TITLE
add new options to keep services running as long as they are ok

### DIFF
--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -1041,18 +1041,27 @@ allow_empty_hostgroup_assignment=0
 # This option will disable all service checks if the host is not in an UP state
 #
 # While desirable in some environments, enabling this value can distort report
-# values as the expected quantity of checks will not have been performed
-
+# values as the expected quantity of checks will not have been performed.
+# Set service_skip_check_host_down_status to -2 to mitigate this.
 #host_down_disable_service_checks=0
+
+# DISABLE SERVICE CHECKS WHEN SERVICE PARENTS DOWN
+# This option will disable all service checks if the service parents are not in an UP state
+#
+# While desirable in some environments, enabling this value can distort report
+# values as the expected quantity of checks will not have been performed.
+# Set service_skip_check_dependency_status to -2 to mitigate this.
+#service_parents_disable_service_checks=0
 
 # SET SERVICE/HOST STATUS WHEN SERVICE CHECK SKIPPED
 # These options will allow you to set the status of a service when its
-# service check is skipped due to one of two reasons:
-# 1) failed dependency check; 2) host not up
+# service check is skipped due to the following reasons:
+# 1) failed dependency check; 2) host not up 3) service parents failed
 # Number 2 can only happen if 'host_down_disable_service_checks' above
 # is set to 1.
 # Valid values for the service* options are:
 #     -1     Do not change the service status (default)
+#     -2     Keep service running as long as it is ok/warning.
 #      0     Set the service status to STATE_OK
 #      1     Set the service status to STATE_WARNING
 #      2     Set the service status to STATE_CRITICAL
@@ -1064,6 +1073,7 @@ allow_empty_hostgroup_assignment=0
 # status of a host when its check is skipped due to a failed dependency check.
 # Valid values for the host_dependency_skip_check_status are:
 #     -1     Do not change the service status (default)
+#     -2     Keep host running as long as it is up.
 #      0     Set the host status to STATE_UP
 #      1     Set the host status to STATE_DOWN
 #      2     Set the host status to STATE_UNREACHABLE

--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -1067,23 +1067,25 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			allow_circular_dependencies = atoi(value);
 		} else if (!strcmp(variable, "host_down_disable_service_checks")) {
 			host_down_disable_service_checks = strtoul(value, NULL, 0);
+		} else if (!strcmp(variable, "service_parents_disable_service_checks")) {
+			service_parents_disable_service_checks = strtoul(value, NULL, 0);
 		} else if (!strcmp(variable, "service_skip_check_dependency_status")) {
 			service_skip_check_dependency_status = atoi(value);
-			if (service_skip_check_dependency_status < -1 || service_skip_check_dependency_status > 3) {
+			if (service_skip_check_dependency_status < -2 || service_skip_check_dependency_status > 3) {
 				nm_asprintf(&error_message, "Illegal value for service_skip_check_dependency_status");
 				error = TRUE;
 				break;
 			}
 		} else if (!strcmp(variable, "service_skip_check_host_down_status")) {
 			service_skip_check_host_down_status = atoi(value);
-			if (service_skip_check_host_down_status < -1 || service_skip_check_host_down_status > 3) {
+			if (service_skip_check_host_down_status < -2 || service_skip_check_host_down_status > 3) {
 				nm_asprintf(&error_message, "Illegal value for service_skip_check_host_down_status");
 				error = TRUE;
 				break;
 			}
 		} else if (!strcmp(variable, "host_skip_check_dependency_status")) {
 			host_skip_check_dependency_status = atoi(value);
-			if (host_skip_check_dependency_status < -1 || host_skip_check_dependency_status > 3) {
+			if (host_skip_check_dependency_status < -2 || host_skip_check_dependency_status > 3) {
 				nm_asprintf(&error_message, "Illegal value for host_skip_check_dependency_status");
 				error = TRUE;
 				break;

--- a/src/naemon/defaults.h
+++ b/src/naemon/defaults.h
@@ -89,6 +89,8 @@
 #define DEFAULT_ALLOW_CIRCULAR_DEPENDENCIES             0        /* Allow circular dependencies */
 #define DEFAULT_HOST_DOWN_DISABLE_SERVICE_CHECKS        0        /* run service checks if the host is down */
 #define DEFAULT_SKIP_CHECK_STATUS                      -1        /* do not change status by default */
+#define SKIP_KEEP_RUNNING_WHEN_UP                      -2        /* run service checks as long as the host and service is up (ok/warning) */
+#define DEFAULT_SERVICE_PARENTS_DISABLE_SERVICE_CHECKS  0        /* run service checks if service parents are down */
 
 #define DEFAULT_HOST_PERFDATA_FILE_TEMPLATE "[HOSTPERFDATA]\t$TIMET$\t$HOSTNAME$\t$HOSTEXECUTIONTIME$\t$HOSTOUTPUT$\t$HOSTPERFDATA$"
 #define DEFAULT_SERVICE_PERFDATA_FILE_TEMPLATE "[SERVICEPERFDATA]\t$TIMET$\t$HOSTNAME$\t$SERVICEDESC$\t$SERVICEEXECUTIONTIME$\t$SERVICELATENCY$\t$SERVICEOUTPUT$\t$SERVICEPERFDATA$"

--- a/src/naemon/globals.h
+++ b/src/naemon/globals.h
@@ -146,6 +146,7 @@ extern unsigned long max_debug_file_size;
 extern int allow_empty_hostgroup_assignment;
 extern int allow_circular_dependencies;
 extern int host_down_disable_service_checks;
+extern int service_parents_disable_service_checks;
 extern int service_skip_check_dependency_status;
 extern int service_skip_check_host_down_status;
 extern int host_skip_check_dependency_status;

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -165,6 +165,7 @@ char *use_timezone = NULL;
 int allow_empty_hostgroup_assignment = DEFAULT_ALLOW_EMPTY_HOSTGROUP_ASSIGNMENT;
 int allow_circular_dependencies = DEFAULT_ALLOW_CIRCULAR_DEPENDENCIES;
 int host_down_disable_service_checks = DEFAULT_HOST_DOWN_DISABLE_SERVICE_CHECKS;
+int service_parents_disable_service_checks = DEFAULT_SERVICE_PARENTS_DISABLE_SERVICE_CHECKS;
 int service_skip_check_dependency_status = DEFAULT_SKIP_CHECK_STATUS;
 int service_skip_check_host_down_status = DEFAULT_SKIP_CHECK_STATUS;
 int host_skip_check_dependency_status = DEFAULT_SKIP_CHECK_STATUS;


### PR DESCRIPTION
The issue with the options:

- host_down_disable_service_checks
- service_skip_check_dependency_status
- service_skip_check_host_down_status
- host_skip_check_dependency_status

is that reports break because hosts/services suddenly stop executing and
keep their OK state. Which makes those options pretty unusable.

So in order to keep reporting correct, you need to keep services running, even
if the host is down. With these new options, hosts/services keep on running as
long as they are up. And as soon as the service is down, it stops running until
the host comes back up. That way naemon has to do less checks, especially less
checks which run into timeouts and such but reporting is still correct.

The option service_skip_check_dependency_status=-2 will also be used for service parents.

Adding a new option service_parents_disable_service_checks to prevent running service
checks if service parents are down.

Recommended settings are:

    host_down_disable_service_checks=1       ; disable service checks if host is down
    service_parents_disable_service_checks=1 ; also disable service checks if parents are down
    service_skip_check_host_down_status=-2   ; but keep running as long as they are ok
    service_skip_check_dependency_status=-2  ; same, but for dependency checks.
    host_skip_check_dependency_status=-2     ; and for host checks.

