### PR TITLE
Add option -i to ignore config warnings.

### DIFF
--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -1451,13 +1451,13 @@ int pre_flight_object_check(int *w, int *e)
 	/*****************************************/
 	/* check each service...                 */
 	/*****************************************/
-	total_objects = 0;
-	for (temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
+	/* Since these checks only generate warnings, skip them all if warnings are ignored. */
+	if (!ignore_warnings) {
+		total_objects = 0;
+		for (temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 
-		total_objects++;
+			total_objects++;
 
-		/* Since these checks only generate warnings, skip them all if warnings are ignored. */
-		if (!ignore_warnings) {
 			/* check for sane recovery options */
 			if (temp_service->notification_options == OPT_RECOVERY) {
 				nm_log(NSLOG_VERIFICATION_WARNING, "Warning: Recovery notification option in service '%s' for host '%s' doesn't make any sense - specify warning and/or critical options as well", temp_service->description, temp_service->host_name);
@@ -1488,23 +1488,28 @@ int pre_flight_object_check(int *w, int *e)
 				warnings++;
 			}
 		}
+
+		if (verify_config) {
+			printf("\tChecked %d services.\n", total_objects);
+		}
 	}
 
-	if (verify_config)
-		printf("\tChecked %d services.\n", total_objects);
-
-
+	if (ignore_warnings) {
+		if (verify_config) {
+			printf("Option -i used. Skipped checking services...\n");
+		}
+	}
 
 	/*****************************************/
 	/* check all hosts...                    */
 	/*****************************************/
-	total_objects = 0;
-	for (temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
+	/* Since these checks only generate warnings, skip them all if warnings are ignored. */
+	if (!ignore_warnings) {
+		total_objects = 0;
+		for (temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
-		total_objects++;
+			total_objects++;
 
-		/* Since these checks only generate warnings, skip them all if warnings are ignored. */
-		if (!ignore_warnings) {
 			/* make sure each host has at least one service associated with it */
 			if (temp_host->services == NULL && verify_config >= 2) {
 				nm_log(NSLOG_VERIFICATION_WARNING, "Warning: Host '%s' has no services associated with it!", temp_host->name);
@@ -1522,11 +1527,17 @@ int pre_flight_object_check(int *w, int *e)
 				warnings++;
 			}
 		}
+
+		if (verify_config) {
+			printf("\tChecked %d hosts.\n", total_objects);
+		}
 	}
 
-	if (verify_config)
-		printf("\tChecked %d hosts.\n", total_objects);
-
+	if (ignore_warnings) {
+		if (verify_config) {
+			printf("Option -i used. Skipped checking hosts...\n");
+		}
+	}
 
 	/*****************************************/
 	/* check all contacts...                 */

--- a/src/naemon/globals.h
+++ b/src/naemon/globals.h
@@ -70,6 +70,7 @@ extern int notification_timeout;
 
 extern volatile sig_atomic_t sig_id;
 
+extern int ignore_warnings;
 extern int verify_config;
 extern int precache_objects;
 extern int use_precached_objects;

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -144,6 +144,7 @@ int main(int argc, char **argv)
 		{"version", no_argument, 0, 'V'},
 		{"license", no_argument, 0, 'V'},
 		{"verify-config", no_argument, 0, 'v'},
+		{"ignore-warnings", no_argument, 0, 'i'},
 		{"daemon", no_argument, 0, 'd'},
 		{"precache-objects", no_argument, 0, 'p'},
 		{"use-precached-objects", no_argument, 0, 'u'},
@@ -161,7 +162,7 @@ int main(int argc, char **argv)
 
 	/* get all command line arguments */
 	while (1) {
-		c = getopt(argc, argv, "+hVvdspuxTW");
+		c = getopt(argc, argv, "+hVvidspuxTW");
 
 		if (c == -1 || c == EOF)
 			break;
@@ -179,6 +180,10 @@ int main(int argc, char **argv)
 
 		case 'v': /* verify */
 			verify_config++;
+			break;
+
+		case 'i': /* ignore warnings */
+			ignore_warnings++;
 			break;
 
 		case 's': /* scheduling check */
@@ -276,6 +281,7 @@ int main(int argc, char **argv)
 		printf("Options:\n");
 		printf("\n");
 		printf("  -v, --verify-config          Verify all configuration data (-v -v for more info)\n");
+		printf("  -i, --ignore-warnings        Ignore all checks that generate warnings when verifying the config\n");
 		printf("  -T, --enable-timing-point    Enable timed commentary on initialization\n");
 		printf("  -x, --dont-verify-paths      Deprecated (Don't check for circular object paths)\n");
 		printf("  -p, --precache-objects       Precache object configuration\n");

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -130,6 +130,7 @@ unsigned long retained_process_service_attribute_mask = 0L;
 unsigned long next_event_id = 0L;
 unsigned long next_comment_id = 0L;
 
+int ignore_warnings = FALSE;
 int verify_config = FALSE;
 int precache_objects = FALSE;
 int use_precached_objects = FALSE;


### PR DESCRIPTION
This is an attempt to improve reload speed in huge environments. If Warnings are not going to be acted upon, an option to skip checking for them during the pre-flight-check or when running a verification would save some seconds for really large environments.

- Add option -i / --ignore-warnings, which will skip checking for configuration issues that only yield warnings. Errors will still be looked for.