### PR TITLE
launch command worker earlier

### DIFF
--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -145,7 +145,7 @@ def naemon_started_and_ready(context, timeout_s):
             # When we see this line in the log, we'll wait 1 more second and
             # then Naemon should be ready, with signal handlers setup so that a
             # test can SIGTERM it.
-            if 'Successfully launched command file worker with pid' in log:
+            if 'Naemon successfully initialized' in log:
                 ready = True
                 time.sleep(1)
                 break

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -19,6 +19,7 @@
 #include "globals.h"
 #include "logging.h"
 #include "nm_alloc.h"
+#include "query-handler.h"
 #include "lib/libnaemon.h"
 #include <string.h>
 #include <sys/types.h>
@@ -387,6 +388,13 @@ int launch_command_file_worker(void)
 
 	/* make our own process-group so we can be traced into and stuff */
 	setpgid(0, 0);
+
+
+	// close inherited file handles
+	close_log_file();
+	close_standard_fds();
+	qh_close_socket();
+	close_lockfile_fd();
 
 	str = nm_strdup(command_file);
 	free_memory(get_global_macros());

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -719,6 +719,8 @@ int main(int argc, char **argv)
 			}
 		}
 
+		nm_log(NSLOG_INFO_MESSAGE, "Naemon successfully initialized (PID=%d)\n", (int)getpid());
+
 		timing_point("Entering event execution loop\n");
 		/***** start monitoring all services *****/
 		/* (doesn't return until a restart or shutdown signal is encountered) */

--- a/src/naemon/query-handler.c
+++ b/src/naemon/query-handler.c
@@ -394,7 +394,7 @@ int qh_init(const char *path)
 	result = iobroker_register(nagios_iobs, qh_listen_sock, NULL, qh_registration_input);
 	if (result < 0) {
 		g_hash_table_destroy(qh_table);
-		close(qh_listen_sock);
+		qh_close_socket();
 		nm_log(NSLOG_RUNTIME_ERROR, "qh: Failed to register socket with io broker: %s\n", iobroker_strerror(result));
 		return ERROR;
 	}
@@ -407,4 +407,10 @@ int qh_init(const char *path)
 	qh_register_handler("help", "Help for the query handler", 0, qh_help);
 
 	return 0;
+}
+
+void qh_close_socket() {
+	if( qh_listen_sock > 0 )
+		close(qh_listen_sock);
+	qh_listen_sock = -1;
 }

--- a/src/naemon/query-handler.h
+++ b/src/naemon/query-handler.h
@@ -20,6 +20,7 @@ int qh_init(const char *path);
 void qh_deinit(const char *path);
 int qh_register_handler(const char *name, const char *description, unsigned int options, qh_handler handler);
 const char *qh_strerror(int code);
+void qh_close_socket(void);
 
 NAGIOS_END_DECL
 

--- a/src/naemon/utils.h
+++ b/src/naemon/utils.h
@@ -37,6 +37,7 @@ void signal_react(void);				/* General signal reaction routines */
 void handle_sigxfsz(void);				/* handle SIGXFSZ */
 int signal_parent(int);					/* signal parent when daemonizing */
 int daemon_init(void);				     		/* switches to daemon mode */
+void close_lockfile_fd(void);			/* close lock_file file handle */
 
 int init_check_stats(void);
 int update_check_stats(int, time_t);


### PR DESCRIPTION
since the command worker forks from the main naemon process, it inherits all open files like ex.: pidfile, logfiles, etc... It will keep those references open, even if the main process rotates and reopens those files.

This patch closes query handler and pid file references after starting the command worker and also moves starting the command worker before initializing the neb modules, so it won't inherit open logfiles from neb modules.

references:

- https://github.com/ConSol-Monitoring/omd/issues/146