### PR TITLE
Fixed missing OK HARD state after OK SOFT.

### DIFF
--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -840,6 +840,9 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* this is a soft recovery */
 			temp_service->state_type = SOFT_STATE;
 
+			/* this is a soft recovery */
+			temp_service->last_state_was_soft_recovery = TRUE;
+
 			/* log the soft recovery */
 			log_service_event(temp_service);
 			alert_recorded = NEBATTR_CHECK_ALERT;
@@ -851,6 +854,14 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 		/* else no service state change has occurred... */
 		else {
 			log_debug_info(DEBUGL_CHECKS, 1, "Service did not change state.\n");
+
+			if (temp_service->last_state_was_soft_recovery == TRUE) {
+				/* log the hard state after the last check which was a soft recovery */
+				log_service_event(temp_service);
+				alert_recorded = NEBATTR_CHECK_ALERT;
+			}
+
+			temp_service->last_state_was_soft_recovery = FALSE;
 		}
 
 		/* should we obsessive over service checks? */

--- a/src/naemon/objects_service.h
+++ b/src/naemon/objects_service.h
@@ -70,6 +70,7 @@ struct service {
 	int     acknowledgement_type;
 	time_t  acknowledgement_end_time;
 	int     host_problem_at_last_check;
+	int     last_state_was_soft_recovery;
 	int     check_type;
 	int	current_state;
 	int	last_state;


### PR DESCRIPTION
This pull request fixes the missing `OK HARD` state after an `OK SOFT` state:

![image](https://github.com/user-attachments/assets/959342d0-5419-47ca-a3f7-2dcddedfa76e)

