### PR TITLE
Update launch.json with an example how to pass options to gdb

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,15 @@
 
             "launchCompleteCommand": "exec-run",
             "MIMode": "gdb",
+
+            // Especially when working with the Query Handler "Broken Pipe" issues may occur. In this case it is useful to ignore SIGPIPE.
+            //"setupCommands": [
+            //    {
+            //        "description": "Ignore SIGPIPE",
+            //        "text": "handle SIGPIPE nostop noprint pass"
+            //    }
+            //],
+
             "miDebuggerPath": "/usr/bin/gdb",
           }
     ]


### PR DESCRIPTION
Add setupCommand example to default launch.json to demonstrate how to set gdb options.
The example set an option to ignore SIGPIPE