### PR TITLE
fix leaking object.cache file references (fixes #462)

### DIFF
--- a/src/naemon/objects.c
+++ b/src/naemon/objects.c
@@ -42,7 +42,7 @@ int fcache_objects(char *cache_file)
 	}
 
 	/* open the cache file for writing */
-	fp = (FILE *)fopen(tmp_file, "w");
+	fp = (FILE *)fdopen(fd, "w");
 	if (fp == NULL) {
 		unlink(tmp_file);
 		nm_log(NSLOG_CONFIG_WARNING, "Warning: Could not open object cache data file '%s' for writing!\n", tmp_file);


### PR DESCRIPTION
using fopen opens the object.cache a second time and naemon closes just one afterwards. So with every write of the objects.cache file, one reference will be kept and prevents the file from beeing deleted which finally fills the disk with deleted files. Using fdopen solves the issue, since it just reuses the existing fd.