### PR TITLE
Release 1 4 3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,26 @@
+1.4.3 - Nov 19 2024
+===================
+Features:
+* add global notifications handler (#477)
+* add external command to add log entries (#477)
+* add hint of previous object when duplicate detection fails (#479)
+* add options to keep services running as long as they are up (#459)
+* add problem timestamps and duration (#447)
+
+Changed:
+* clean up output of naemon -V (#484)
+* change problem_id and notification_id to uuids (#362)
+* change service parents suppressing only normal notifcations (#446)
+
+Bugfixes:
+* fix leaking object.cache file references (#462)
+* fix host not being in hard state with max_check_attempts=1 (#473)
+* throw config errors if boolean values cannot be parsed (#478)
+* fix retrieving comments after deleting first (#474)
+* fix rpm installation race condition (#456)
+* fix resetting modified_attributes (#449)
+
+
 1.4.2 - Jan 03 2024
 ===================
 Features:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+naemon-core (1.4.3) UNRELEASED; urgency=low
+
+  * new upstream release
+
+ -- Naemon Development Team <naemon-dev@monitoring-lists.org>  Mon, 18 Nov 2024 21:16:47 +0100
+
 naemon-core (1.4.2) UNRELEASED; urgency=low
 
   * new upstream release

--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -2,7 +2,7 @@
 
 Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon-core
-Version: 1.4.2
+Version: 1.4.3
 Release: 0
 License: GPL-2.0-only
 Group: Applications/System

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.4.2
+VERSION=1.4.3
 if test -e .git; then
     if hash git 2>/dev/null; then
         VERSION=$(git describe --tag --exact-match 2>/dev/null | sed -e 's/^v//')


### PR DESCRIPTION
1.4.3 - Nov 19 2024
===================
Features:
* add global notifications handler (#477)
* add external command to add log entries (#477)
* add hint of previous object when duplicate detection fails (#479)
* add options to keep services running as long as they are up (#459)
* add problem timestamps and duration (#447)

Changed:
* clean up output of naemon -V (#484)
* change problem_id and notification_id to uuids (#362)
* change service parents suppressing only normal notifcations (#446)

Bugfixes:
* fix leaking object.cache file references (#462)
* fix host not being in hard state with max_check_attempts=1 (#473)
* throw config errors if boolean values cannot be parsed (#478)
* fix retrieving comments after deleting first (#474)
* fix rpm installation race condition (#456)
* fix resetting modified_attributes (#449)
