### PR TITLE
improve config parser performance

### DIFF
--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -571,6 +571,7 @@ int main(int argc, char **argv)
 
 		/* read in all object config data */
 		if (result == OK) {
+			nm_log(NSLOG_INFO_MESSAGE, "Reading all config object data\n");
 			timing_point("Reading all object data\n");
 			result = read_all_object_data(config_file);
 			timing_point("Read all object data\n");
@@ -587,6 +588,7 @@ int main(int argc, char **argv)
 		timing_point("Initialized Event queue\n");
 
 		/* load modules */
+		nm_log(NSLOG_INFO_MESSAGE, "Loading neb modules\n");
 		timing_point("Loading modules\n");
 		if (neb_load_all_modules() != OK) {
 			nm_log(NSLOG_CONFIG_ERROR, "Error: Module loading failed. Aborting.\n");

--- a/src/naemon/shared.c
+++ b/src/naemon/shared.c
@@ -10,6 +10,7 @@
 #include <sys/time.h>
 #include <fcntl.h>
 #include <glib.h>
+#include <ctype.h>
 #ifdef HAVE_SYS_MMAN_H
 # include <sys/mman.h>
 #endif
@@ -412,6 +413,29 @@ void strip(char *buffer)
 	}
 }
 
+// strip trailing whitespace, returns pointer to stripped string
+char *rstrip(char *c)
+{
+    char *w = c + strlen(c) - 1;
+    while (w >= c && isspace(*w))
+        *w-- = '\0';
+    return c;
+}
+
+// strip trailing whitespace, returns pointer to stripped string
+// NOTE: you need to free the original pointer, not the stripped one
+char *lstrip(char *c)
+{
+    while (isspace(*c)) c++;
+    return c;
+}
+
+// trim leading/trailing whitespace, returns pointer to stripped string
+// NOTE: you need to free the original pointer, not the stripped one
+char *trim(char *c)
+{
+    return(lstrip(rstrip(c)));
+}
 
 /*
  * given a date/time in time_t format, produce a corresponding

--- a/src/naemon/shared.h
+++ b/src/naemon/shared.h
@@ -48,6 +48,9 @@ int mmap_fclose(mmapfile *temp_mmapfile);
 char *mmap_fgets(mmapfile *temp_mmapfile);
 char *mmap_fgets_multiline(mmapfile * temp_mmapfile);
 void strip(char *buffer);
+char *rstrip(char *c);
+char *lstrip(char *c);
+char *trim(char *c);
 void get_datetime_string(time_t *raw_time, char *buffer,
                                 int buffer_length, int type);
 void get_time_breakdown(unsigned long raw_time, int *days, int *hours,

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -1348,7 +1348,7 @@ static int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, cha
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this contact should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -1357,7 +1357,7 @@ static int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, cha
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -1490,7 +1490,7 @@ static int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, 
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this hostgroup should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -1499,7 +1499,7 @@ static int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, 
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -1617,7 +1617,7 @@ static int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char 
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this host should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -1626,7 +1626,7 @@ static int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char 
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -1819,7 +1819,7 @@ static int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, c
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this servicegroup should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -1828,7 +1828,7 @@ static int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, c
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -1967,8 +1967,8 @@ static int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, ch
 			next_p = strchr(p2 + 1, ',');
 			if (next_p)
 				*next_p = 0;
-			strip(p1);
-			strip(p2);
+			p1 = trim(p1);
+			p2 = trim(p2);
 
 			/* now we have arguments we can handle safely, so do that */
 			if (xodtemplate_expand_services(list, reject_map, p1, p2, _config_file, _start_line) != OK) {
@@ -1982,7 +1982,7 @@ static int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, ch
 		return OK;
 
 	/* should we use regular expression matching for the host name? */
-	if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(host_name, "*") || strstr(host_name, "?") || strstr(host_name, "+") || strstr(host_name, "\\."))) {
+	if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(host_name, "*") || strstr(host_name, "?") || strstr(host_name, "+") || strstr(host_name, "\\."))) {
 		use_regexp_host = TRUE;
 		/* compile regular expression for host name */
 		if (regcomp(&preg2, host_name, REG_EXTENDED))
@@ -2000,13 +2000,14 @@ static int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, ch
 		service_wildcard_match = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this service should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
 			reject_item = TRUE;
 			temp_ptr++;
 		}
+
 
 		if (!strcmp(temp_ptr, "*"))
 			service_wildcard_match = TRUE;
@@ -2015,7 +2016,7 @@ static int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, ch
 
 		if (service_wildcard_match == FALSE) {
 			/* should we use regular expression matching for the service description? */
-			if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\."))) {
+			if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\."))) {
 				use_regexp_service = TRUE;
 
 				/* compile regular expression for service description */
@@ -4334,7 +4335,7 @@ static int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xod
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this contactgroup should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -4343,7 +4344,7 @@ static int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xod
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -4507,7 +4508,7 @@ static int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtem
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this hostgroup should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -4516,7 +4517,7 @@ static int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtem
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -4680,7 +4681,7 @@ static int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xod
 		reject_item = FALSE;
 
 		/* strip trailing spaces */
-		strip(temp_ptr);
+		temp_ptr = trim(temp_ptr);
 
 		/* this servicegroup should be excluded (rejected) */
 		if (temp_ptr[0] == '!') {
@@ -4689,7 +4690,7 @@ static int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xod
 		}
 
 		/* should we use regular expression matching? */
-		if (use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
+		if (!use_precached_objects && use_regexp_matches == TRUE && (use_true_regexp_matching == TRUE || strstr(temp_ptr, "*") || strstr(temp_ptr, "?") || strstr(temp_ptr, "+") || strstr(temp_ptr, "\\.")))
 			use_regexp = TRUE;
 		else
 			use_regexp = FALSE;
@@ -4900,9 +4901,7 @@ static int xodtemplate_recombobulate_contactgroups(void)
 				next_ptr = strchr(ptr, ',');
 				if (next_ptr)
 					*next_ptr = 0;
-				while (*ptr == ' ' || *ptr == '\t')
-					ptr++;
-				strip(ptr);
+				ptr = trim(ptr);
 				if (!(cg = xodtemplate_find_real_contactgroup(ptr))) {
 					nm_log(NSLOG_CONFIG_ERROR, "Error: Could not find member group '%s' specified in contactgroup '%s' (config file '%s', starting on line %d)\n", ptr, temp_contactgroup->contactgroup_name, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
 					return ERROR;
@@ -4962,7 +4961,7 @@ static int xodtemplate_recombobulate_contactgroups(void)
 		for (temp_ptr = strtok(contactgroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
 
 			/* strip trailing spaces */
-			strip(temp_ptr);
+			temp_ptr = trim(temp_ptr);
 
 			/* find the contactgroup */
 			temp_contactgroup = xodtemplate_find_real_contactgroup(temp_ptr);
@@ -5076,10 +5075,8 @@ static int xodtemplate_recombobulate_hostgroups(void)
 			next_ptr = strchr(ptr, ',');
 			if (next_ptr)
 				*next_ptr = 0;
-			while (*ptr == ' ' || *ptr == '\t')
-				ptr++;
 
-			strip(ptr);
+			ptr = trim(ptr);
 
 			if (!(hg = xodtemplate_find_real_hostgroup(ptr))) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not find member group '%s' specified in hostgroup '%s' (config file '%s', starting on line %d)\n", ptr, temp_hostgroup->hostgroup_name, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
@@ -5142,7 +5139,7 @@ static int xodtemplate_recombobulate_hostgroups(void)
 		for (temp_ptr = strtok(hostgroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
 
 			/* strip trailing spaces */
-			strip(temp_ptr);
+			temp_ptr = trim(temp_ptr);
 
 			/* find the hostgroup */
 			temp_hostgroup = xodtemplate_find_real_hostgroup(temp_ptr);
@@ -5257,7 +5254,7 @@ static int xodtemplate_recombobulate_servicegroups(void)
 				next_ptr = strchr(ptr, ',');
 				if (next_ptr)
 					*next_ptr = 0;
-				strip(ptr);
+				ptr = trim(ptr);
 				if (!(sg = xodtemplate_find_real_servicegroup(ptr))) {
 					nm_log(NSLOG_CONFIG_ERROR, "Error: Could not find member group '%s' specified in servicegroup '%s' (config file '%s', starting on line %d)\n", ptr, temp_servicegroup->servicegroup_name, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
 					return ERROR;
@@ -5325,7 +5322,7 @@ static int xodtemplate_recombobulate_servicegroups(void)
 		for (temp_ptr = strtok(servicegroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
 
 			/* strip trailing spaces */
-			strip(temp_ptr);
+			temp_ptr = trim(temp_ptr);
 
 			/* find the servicegroup */
 			temp_servicegroup = xodtemplate_find_real_servicegroup(temp_ptr);
@@ -5535,7 +5532,7 @@ static int xodtemplate_register_timeperiod_relations(void *tprd, void *discard)
 	/* add timeperiod exclusions */
 	if (this_timeperiod->exclusions) {
 		for (temp_ptr = strtok(this_timeperiod->exclusions, ","); temp_ptr != NULL; temp_ptr = strtok(NULL, ",")) {
-			strip(temp_ptr);
+			temp_ptr = trim(temp_ptr);
 			new_timeperiodexclusion = add_exclusion_to_timeperiod(new_timeperiod, temp_ptr);
 			if (new_timeperiodexclusion == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add excluded timeperiod '%s' to timeperiod (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
@@ -5745,7 +5742,7 @@ static int xodtemplate_register_host_relations(void *host_, void *discard)
 
 		for (parent_host = strtok(this_host->parents, ","); parent_host != NULL; parent_host = strtok(NULL, ",")) {
 			host *parent;
-			strip(parent_host);
+			parent_host = trim(parent_host);
 			parent = find_host(parent_host);
 			if (add_parent_to_host(new_host, parent) != OK) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add parent host '%s' to host (config file '%s', starting on line %d)\n", parent_host, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
@@ -5759,7 +5756,7 @@ static int xodtemplate_register_host_relations(void *host_, void *discard)
 
 		for (contact_group = strtok(this_host->contact_groups, ","); contact_group != NULL; contact_group = strtok(NULL, ",")) {
 
-			strip(contact_group);
+			contact_group = trim(contact_group);
 			new_contactgroupsmember = add_contactgroup_to_host(new_host, contact_group);
 			if (new_contactgroupsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contactgroup '%s' to host (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
@@ -5773,7 +5770,7 @@ static int xodtemplate_register_host_relations(void *host_, void *discard)
 
 		for (contact_name = strtok(this_host->contacts, ","); contact_name != NULL; contact_name = strtok(NULL, ",")) {
 
-			strip(contact_name);
+			contact_name = trim(contact_name);
 			new_contactsmember = add_contact_to_host(new_host, contact_name);
 			if (new_contactsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contact '%s' to host (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
@@ -5964,7 +5961,7 @@ static int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_
 
 		for (contact_group = strtok(this_hostescalation->contact_groups, ","); contact_group != NULL; contact_group = strtok(NULL, ",")) {
 
-			strip(contact_group);
+			contact_group = trim(contact_group);
 			new_contactgroupsmember = add_contactgroup_to_hostescalation(new_hostescalation, contact_group);
 			if (new_contactgroupsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contactgroup '%s' to host escalation (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
@@ -5978,7 +5975,7 @@ static int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_
 
 		for (contact_name = strtok(this_hostescalation->contacts, ","); contact_name != NULL; contact_name = strtok(NULL, ",")) {
 
-			strip(contact_name);
+			contact_name = trim(contact_name);
 			new_contactsmember = add_contact_to_hostescalation(new_hostescalation, contact_name);
 			if (new_contactsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contact '%s' to host escalation (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
@@ -6106,7 +6103,7 @@ static int xodtemplate_register_service_relations(void *srv, void *discard)
 
 		for (contact_group = strtok(this_service->contact_groups, ","); contact_group != NULL; contact_group = strtok(NULL, ",")) {
 
-			strip(contact_group);
+			contact_group = trim(contact_group);
 			new_contactgroupsmember = add_contactgroup_to_service(new_service, contact_group);
 			if (new_contactgroupsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contactgroup '%s' to service (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
@@ -6121,7 +6118,7 @@ static int xodtemplate_register_service_relations(void *srv, void *discard)
 		for (contact_name = strtok(this_service->contacts, ","); contact_name != NULL; contact_name = strtok(NULL, ",")) {
 
 			/* add this contact to the service definition */
-			strip(contact_name);
+			contact_name = trim(contact_name);
 			new_contactsmember = add_contact_to_service(new_service, contact_name);
 
 			/* stop adding contacts if we ran into an error */
@@ -6251,6 +6248,26 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 		nm_free(temp_servicedependency->dependent_host_name);
 		nm_free(temp_servicedependency->dependent_service_description);
 		nm_free(temp_servicedependency->dependent_hostgroup_name);
+		nm_free(temp_servicedependency);
+		return OK;
+	}
+
+	/* take a shortcut here, hosts/services have been expanded and checked already */
+	if(use_precached_objects) {
+		if (xodtemplate_register_servicedependency(temp_servicedependency) != OK) {
+			nm_log(NSLOG_VERIFICATION_WARNING, "Error: Failed to register servicedependency from '%s;%s' to '%s;%s' (config file '%s', starting at line %d)\n",
+					hname, sdesc,
+					dhname, dsdesc,
+					xodtemplate_config_file_name(temp_servicedependency->_config_file), temp_servicedependency->_start_line);
+			return ERROR;
+		}
+		nm_free(temp_servicedependency->host_name);
+		nm_free(temp_servicedependency->service_description);
+		nm_free(temp_servicedependency->hostgroup_name);
+		nm_free(temp_servicedependency->dependent_host_name);
+		nm_free(temp_servicedependency->dependent_service_description);
+		nm_free(temp_servicedependency->dependent_hostgroup_name);
+		nm_free(temp_servicedependency);
 		return OK;
 	}
 
@@ -6415,7 +6432,7 @@ static int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation 
 
 		for (contact_group = strtok(this_serviceescalation->contact_groups, ","); contact_group != NULL; contact_group = strtok(NULL, ",")) {
 
-			strip(contact_group);
+			contact_group = trim(contact_group);
 			new_contactgroupsmember = add_contactgroup_to_serviceescalation(new_serviceescalation, contact_group);
 			if (new_contactgroupsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contactgroup '%s' to service escalation (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
@@ -6429,7 +6446,7 @@ static int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation 
 
 		for (contact_name = strtok(this_serviceescalation->contacts, ","); contact_name != NULL; contact_name = strtok(NULL, ",")) {
 
-			strip(contact_name);
+			contact_name = trim(contact_name);
 			new_contactsmember = add_contact_to_serviceescalation(new_serviceescalation, contact_name);
 			if (new_contactsmember == NULL) {
 				nm_log(NSLOG_CONFIG_ERROR, "Error: Could not add contact '%s' to service escalation (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
@@ -6617,11 +6634,7 @@ static int xodtemplate_add_object_property(char *input)
 		value = input + x;
 	} else {
 		/* get variable value */
-		value = input + x + 1;
-		while (*value == ' ' || *value == '\t')
-			value++;
-		/* now strip trailing spaces */
-		strip(value);
+		value = trim(input + x + 1);
 	}
 
 	switch (xodtemplate_current_object_type) {
@@ -8299,6 +8312,7 @@ static int xodtemplate_process_config_file(char *filename)
 {
 	mmapfile *thefile = NULL;
 	char *input = NULL;
+	char *inputbuf = NULL;
 	register int in_definition = FALSE;
 	register int current_line = 0;
 	int result = OK;
@@ -8327,34 +8341,39 @@ static int xodtemplate_process_config_file(char *filename)
 	/* read in all lines from the config file */
 	while (1) {
 
-		nm_free(input);
+		nm_free(inputbuf);
 
 		/* read the next line */
-		if ((input = mmap_fgets_multiline(thefile)) == NULL)
-			break;
+		if(use_precached_objects) {
+			/* no multilines on precached file */
+			if ((inputbuf = mmap_fgets(thefile)) == NULL)
+				break;
+		} else {
+			if ((inputbuf = mmap_fgets_multiline(thefile)) == NULL)
+				break;
+			/* grab data before comment delimiter - faster than a strtok() and strncpy()... */
+			for (x = 0; inputbuf[x] != '\x0'; x++) {
+				if (inputbuf[x] == ';') {
+					if (x == 0)
+						break;
+					else if (inputbuf[x - 1] != '\\')
+						break;
+				}
+			}
+			inputbuf[x] = '\x0';
+		}
 
 		current_line = thefile->current_line;
 
-		/* grab data before comment delimiter - faster than a strtok() and strncpy()... */
-		for (x = 0; input[x] != '\x0'; x++) {
-			if (input[x] == ';') {
-				if (x == 0)
-					break;
-				else if (input[x - 1] != '\\')
-					break;
-			}
-		}
-		input[x] = '\x0';
-
 		/* strip input */
-		strip(input);
+		input = trim(inputbuf);
 
 		/* skip empty lines */
 		if (input[0] == '\x0' || input[0] == '#')
 			continue;
 
 		/* this is the start of an object definition */
-		if (strstr(input, "define") == input) {
+		if (!strncmp(input, "define", 6)) {
 
 			/* get the type of object we're defining... */
 			for (x = 6; input[x] != '\x0'; x++)
@@ -8454,7 +8473,7 @@ static int xodtemplate_process_config_file(char *filename)
 		}
 	}
 
-	nm_free(input);
+	nm_free(inputbuf);
 	mmap_fclose(thefile);
 
 	/* whoops - EOF while we were in the middle of an object definition... */

--- a/src/naemon/xrddefault.c
+++ b/src/naemon/xrddefault.c
@@ -566,13 +566,7 @@ int xrddefault_read_state_information(void)
 		if ((inputbuf = mmap_fgets(thefile)) == NULL)
 			break;
 
-		input = inputbuf;
-
-		/* far better than strip()ing */
-		if (input[0] == '\t')
-			input++;
-
-		strip(input);
+		input = trim(inputbuf);
 
 		if (!strcmp(input, "service {")) {
 			memset(&conf, 0, sizeof(conf));


### PR DESCRIPTION
- use faster trim method
- skip sanitizing dependencies when reading precached objects
- skip regexp matching when reading precached objects