### PR TITLE
postpone check until check period starts

### DIFF
--- a/src/naemon/checks_host.h
+++ b/src/naemon/checks_host.h
@@ -28,6 +28,9 @@ int check_host_dependencies(host *hst, int dependency_type);
 /* adjusts current host check attempt when a check is processed */
 int adjust_host_check_attempt(host *hst, int is_active);
 
+/* ensure next check falls into check period */
+void delay_host_if_next_check_is_outside_timeperiod(host *);
+
 NAGIOS_END_DECL
 
 #endif

--- a/src/naemon/checks_service.h
+++ b/src/naemon/checks_service.h
@@ -24,6 +24,9 @@ int handle_async_service_check_result(service *, check_result *);
 /* Immutable, check if service is reachable */
 int check_service_dependencies(service *, int);
 
+/* ensure next check falls into check period */
+void delay_service_if_next_check_is_outside_timeperiod(service *);
+
 NAGIOS_END_DECL
 
 #endif

--- a/src/naemon/objects_timeperiod.c
+++ b/src/naemon/objects_timeperiod.c
@@ -661,8 +661,6 @@ int check_time_against_period(time_t test_time, const timeperiod *tperiod)
 	timerange *temp_timerange = NULL;
 	time_t midnight = (time_t)0L;
 
-	midnight = get_midnight(test_time);
-
 	/* if no period was specified, assume the time is good */
 	if (tperiod == NULL)
 		return OK;
@@ -670,6 +668,7 @@ int check_time_against_period(time_t test_time, const timeperiod *tperiod)
 	if (is_time_excluded(test_time, tperiod))
 		return ERROR;
 
+	midnight = get_midnight(test_time);
 	for (temp_timerange = _get_matching_timerange(test_time, tperiod); temp_timerange != NULL; temp_timerange = temp_timerange->next) {
 		if (timerange_includes_time(temp_timerange, test_time - midnight))
 			return OK;


### PR DESCRIPTION
Given a service with a 24h check interval and a office hours check period. If this service is scheduled for whatever reasons outside office hours, it will be rescheduled 24hours again which is also outside office hours.
In the end, this service will never be checked again.

So, when naemon detects a check which could not be run because it is outside the check period, postpone the check until the next slot in its check period.