### PR TITLE
add support for configurable relative configuration paths

### DIFF
--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -11,7 +11,7 @@
 
 
 # BASE DIRECTORY
-# ALl (not absolute) paths in this config file are relative to the folder of
+# All (not absolute) paths in this config file are relative to the folder of
 # the naemon.cfg file. If you want use paths relative to a different folder,
 # use this option.
 #config_rel_path=@pkgconfdir@

--- a/sample-config/naemon.cfg.in
+++ b/sample-config/naemon.cfg.in
@@ -10,6 +10,13 @@
 ##############################################################################
 
 
+# BASE DIRECTORY
+# ALl (not absolute) paths in this config file are relative to the folder of
+# the naemon.cfg file. If you want use paths relative to a different folder,
+# use this option.
+#config_rel_path=@pkgconfdir@
+
+
 # LOG FILE
 # This is the main log file where service and host events are logged
 # for historical purposes.  This should be the first option specified

--- a/src/naemon/common.h
+++ b/src/naemon/common.h
@@ -44,6 +44,7 @@ extern int obsess_over_hosts;
 extern int enable_timing_point;
 
 extern char *config_file_dir;
+extern char *config_rel_path;
 
 #ifdef HAVE_TZNAME
 #ifdef CYGWIN

--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -109,7 +109,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 
 			/* save the macro */
 			nm_free(mac->x[MACRO_RESOURCEFILE]);
-			mac->x[MACRO_RESOURCEFILE] = nspath_absolute(value, config_file_dir);
+			mac->x[MACRO_RESOURCEFILE] = nspath_absolute(value, config_rel_path);
 
 			/* process the resource file */
 			if (read_resource_file(mac->x[MACRO_RESOURCEFILE]) == ERROR) {
@@ -117,11 +117,16 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 		}
 
+		else if (!strcmp(variable, "config_rel_path")) {
+			nm_free(config_rel_path);
+			config_rel_path = nspath_absolute(value, NULL);
+		}
+
 		else if (!strcmp(variable, "check_workers"))
 			num_check_workers = atoi(value);
 		else if (!strcmp(variable, "query_socket")) {
 			nm_free(qh_socket_path);
-			qh_socket_path = nspath_absolute(value, config_file_dir);
+			qh_socket_path = nspath_absolute(value, config_rel_path);
 		} else if (!strcmp(variable, "log_file")) {
 
 			if (strlen(value) > MAX_FILENAME_LENGTH - 1) {
@@ -131,7 +136,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(log_file);
-			log_file = nspath_absolute(value, config_file_dir);
+			log_file = nspath_absolute(value, config_rel_path);
 			/* make sure the configured logfile takes effect */
 			close_log_file();
 		} else if (!strcmp(variable, "debug_level"))
@@ -149,7 +154,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(debug_file);
-			debug_file = nspath_absolute(value, config_file_dir);
+			debug_file = nspath_absolute(value, config_rel_path);
 		}
 
 		else if (!strcmp(variable, "max_debug_file_size"))
@@ -164,7 +169,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(command_file);
-			command_file = nspath_absolute(value, config_file_dir);
+			command_file = nspath_absolute(value, config_rel_path);
 
 			/* save the macro */
 			mac->x[MACRO_COMMANDFILE] = command_file;
@@ -177,7 +182,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 
 		else if (!strcmp(variable, "temp_path")) {
 			nm_free(temp_path);
-			temp_path = nspath_absolute(value, config_file_dir);
+			temp_path = nspath_absolute(value, config_rel_path);
 		}
 
 		else if (!strcmp(variable, "check_result_path")) {
@@ -188,7 +193,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(check_result_path);
-			check_result_path = nspath_absolute(value, config_file_dir);
+			check_result_path = nspath_absolute(value, config_rel_path);
 			/* make sure we don't have a trailing slash */
 			if (check_result_path[strlen(check_result_path) - 1] == '/')
 				check_result_path[strlen(check_result_path) - 1] = '\x0';
@@ -215,7 +220,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(lock_file);
-			lock_file = nspath_absolute(value, config_file_dir);
+			lock_file = nspath_absolute(value, config_rel_path);
 		}
 
 		else if (!strcmp(variable, "global_host_event_handler")) {
@@ -640,7 +645,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			}
 
 			nm_free(log_archive_path);
-			log_archive_path = nspath_absolute(value, config_file_dir);
+			log_archive_path = nspath_absolute(value, config_rel_path);
 		}
 
 		else if (!strcmp(variable, "enable_event_handlers"))
@@ -912,7 +917,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 		else if (!strcmp(variable, "broker_module")) {
 			modptr = strtok(value, " \n");
 			argptr = strtok(NULL, "\n");
-			modptr = nspath_absolute(modptr, config_file_dir);
+			modptr = nspath_absolute(modptr, config_rel_path);
 			if (modptr) {
 				neb_add_module(modptr, argptr, TRUE);
 				free(modptr);
@@ -962,9 +967,9 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 
 		/* BEGIN status data variables */
 		else if (!strcmp(variable, "status_file"))
-			status_file = nspath_absolute(value, config_file_dir);
+			status_file = nspath_absolute(value, config_rel_path);
 		else if (strstr(input, "state_retention_file=") == input)
-			retention_file = nspath_absolute(value, config_file_dir);
+			retention_file = nspath_absolute(value, config_rel_path);
 		/* END status data variables */
 
 		/*** BEGIN perfdata variables ***/
@@ -979,9 +984,9 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 		else if (!strcmp(variable, "service_perfdata_file_template"))
 			service_perfdata_file_template = nm_strdup(value);
 		else if (!strcmp(variable, "host_perfdata_file"))
-			host_perfdata_file = nspath_absolute(value, config_file_dir);
+			host_perfdata_file = nspath_absolute(value, config_rel_path);
 		else if (!strcmp(variable, "service_perfdata_file"))
-			service_perfdata_file = nspath_absolute(value, config_file_dir);
+			service_perfdata_file = nspath_absolute(value, config_rel_path);
 		else if (!strcmp(variable, "host_perfdata_file_mode")) {
 			host_perfdata_file_pipe = FALSE;
 			if (strstr(value, "p") != NULL)
@@ -1013,11 +1018,11 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 		/*** END perfdata variables */
 
 		else if (!strcmp(variable, "cfg_file")) {
-			add_object_to_objectlist(&objcfg_files, nspath_absolute(value, config_file_dir));
+			add_object_to_objectlist(&objcfg_files, nspath_absolute(value, config_rel_path));
 		} else if (!strcmp(variable, "cfg_dir")) {
-			add_object_to_objectlist(&objcfg_dirs, nspath_absolute(value, config_file_dir));
+			add_object_to_objectlist(&objcfg_dirs, nspath_absolute(value, config_rel_path));
 		} else if (!strcmp(variable, "include_file")) {
-			char *include_file = nspath_absolute(value, config_file_dir);
+			char *include_file = nspath_absolute(value, config_rel_path);
 			if (prepend_unique_object_to_objectlist(&maincfg_files, include_file, (int (*)(const void *, const void *))strcmp) == OBJECTLIST_DUPE) {
 				error = TRUE;
 				nm_asprintf(&error_message, "Error: File %s explicitly included more than once", include_file);
@@ -1026,7 +1031,7 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			error |= read_config_file(include_file, mac);
 			nm_free(include_file);
 		} else if (!strcmp(variable, "include_dir")) {
-			char *include_dir = nspath_absolute(value, config_file_dir);
+			char *include_dir = nspath_absolute(value, config_rel_path);
 			DIR *dirp = NULL;
 			struct dirent *dirfile = NULL;
 
@@ -1076,12 +1081,12 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 			nm_free(include_dir);
 		} else if (strstr(input, "object_cache_file=") == input) {
 			nm_free(object_cache_file);
-			object_cache_file = nspath_absolute(value, config_file_dir);
+			object_cache_file = nspath_absolute(value, config_rel_path);
 			nm_free(mac->x[MACRO_OBJECTCACHEFILE]);
 			mac->x[MACRO_OBJECTCACHEFILE] = nm_strdup(object_cache_file);
 		} else if (strstr(input, "precached_object_file=") == input) {
 			nm_free(object_precache_file);
-			object_precache_file = nspath_absolute(value, config_file_dir);
+			object_precache_file = nspath_absolute(value, config_rel_path);
 		} else if (!strcmp(variable, "allow_empty_hostgroup_assignment")) {
 			allow_empty_hostgroup_assignment = (atoi(value) > 0) ? TRUE : FALSE;
 		} else if (!strcmp(variable, "allow_circular_dependencies")) {
@@ -1198,7 +1203,7 @@ int read_main_config_file(const char *main_config_file)
 	} else if (*temp_file == '.') {
 		/* temp_file is relative. Make it naemon.cfg-relative */
 		char *foo = temp_file;
-		temp_file = nspath_absolute(temp_file, config_file_dir);
+		temp_file = nspath_absolute(temp_file, config_rel_path);
 		free(foo);
 	} else if (*temp_file != '/') {
 		/*

--- a/src/naemon/naemon.c
+++ b/src/naemon/naemon.c
@@ -323,6 +323,8 @@ int main(int argc, char **argv)
 	}
 
 	config_file_dir = nspath_absolute_dirname(config_file, NULL);
+	if(config_file_dir != NULL)
+		config_rel_path = nm_strdup(config_file_dir);
 
 	/*
 	 * Set the signal handler for the SIGXFSZ signal here because
@@ -433,8 +435,9 @@ int main(int argc, char **argv)
 
 		/* make valgrind shut up about still reachable memory */
 		neb_free_module_list();
-		free(config_file_dir);
-		free(config_file);
+		nm_free(config_file_dir);
+		nm_free(config_rel_path);
+		nm_free(config_file);
 
 		exit(result);
 	}
@@ -779,6 +782,7 @@ int main(int argc, char **argv)
 	nm_free(lock_file);
 	nm_free(config_file);
 	nm_free(config_file_dir);
+	nm_free(config_rel_path);
 	nm_free(naemon_binary_path);
 
 	return OK;

--- a/src/naemon/shared.c
+++ b/src/naemon/shared.c
@@ -53,6 +53,7 @@ int obsess_over_hosts = FALSE;
 unsigned long next_downtime_id = 0;
 
 char *config_file_dir = NULL;
+char *config_rel_path = NULL;
 
 
 /* silly debug-ish helper used to track down hotspots in config parsing */

--- a/t-tap/test_commands.c
+++ b/t-tap/test_commands.c
@@ -723,6 +723,7 @@ int main(int /*@unused@*/ argc, char /*@unused@*/ **arv)
 	init_event_queue();
 
 	config_file_dir = nspath_absolute_dirname(test_config_file, NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	assert(OK == read_main_config_file(test_config_file));
 	assert(OK == read_all_object_data(test_config_file));
 	assert(OK == initialize_downtime_data());

--- a/t-tap/test_config.c
+++ b/t-tap/test_config.c
@@ -56,6 +56,7 @@ int main(int argc, char **argv)
 
 	config_file = strdup(TESTDIR "naemon.cfg");
 	config_file_dir = nspath_absolute_dirname(config_file, NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	/* read in the configuration files (main config file, resource and object config files) */
 	result = read_main_config_file(config_file);
 	ok(result == OK, "Read main configuration file okay - if fails, use nagios -v to check");

--- a/t-tap/test_timeperiods.c
+++ b/t-tap/test_timeperiods.c
@@ -139,6 +139,7 @@ int main(int argc, char **argv)
 
 	config_file = strdup(TESTDIR "naemon.cfg");
 	config_file_dir = nspath_absolute_dirname(config_file, NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	/* read in the configuration files (main config file, resource and object config files) */
 	result = read_main_config_file(config_file);
 	ok(result == OK, "Read main configuration file okay - if fails, use nagios -v to check");

--- a/tests/test-config.c
+++ b/tests/test-config.c
@@ -19,6 +19,7 @@ START_TEST(services)
 	res = reset_variables();
 	ck_assert_int_eq(OK, res);
 	config_file_dir = nspath_absolute_dirname(TESTDIR "services/naemon.cfg", NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	res = read_main_config_file(TESTDIR "services/naemon.cfg");
 	ck_assert_int_eq(OK, res);
 	res = read_all_object_data(TESTDIR "services/naemon.cfg");
@@ -35,6 +36,7 @@ START_TEST(services)
 	ck_assert_int_eq(2, s5_hits);
 	ck_assert_int_eq(5, hits);
 	nm_free(config_file_dir);
+	nm_free(config_rel_path);
 	cleanup();
 }
 END_TEST
@@ -52,6 +54,7 @@ START_TEST(recursive)
 	res = reset_variables();
 	ck_assert_int_eq(OK, res);
 	config_file_dir = nspath_absolute_dirname(TESTDIR "recursive/naemon.cfg", NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	res = read_main_config_file(TESTDIR "recursive/naemon.cfg");
 	ck_assert_int_eq(OK, res);
 	res = read_all_object_data(TESTDIR "recursive/naemon.cfg");
@@ -68,6 +71,7 @@ START_TEST(recursive)
 	}
 	ck_assert_msg(hits == 2, "Expected 2 hosts, found %i", hits);
 	nm_free(config_file_dir);
+	nm_free(config_rel_path);
 	cleanup();
 }
 END_TEST
@@ -80,6 +84,7 @@ START_TEST(main_include)
 	objcfg_files = NULL;
 	objcfg_dirs = NULL;
 	config_file_dir = nspath_absolute_dirname(TESTDIR "inc/naemon.cfg", NULL);
+	config_rel_path = nm_strdup(config_file_dir);
 	res = read_main_config_file(TESTDIR "inc/naemon.cfg");
 	ck_assert_int_eq(OK, res);
 	ck_assert_int_eq(1448, event_handler_timeout);
@@ -93,6 +98,7 @@ START_TEST(main_include)
 	nm_free(file_cfg);
 	nm_free(dir_cfg);
 	nm_free(config_file_dir);
+	nm_free(config_rel_path);
 }
 END_TEST
 


### PR DESCRIPTION
Naemon already supports relative include paths and uses the folder of the main naemon.cfg as base path.

This is fine unless you want to generate the main naemon.cfg and start naemon from a tmp folder. In this case, i'd like to set the base path from the config file.

By default nothing changes, but you can now override this by setting `config_rel_path`.