### PR TITLE
fix crash in check post processing

### DIFF
--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -317,7 +317,8 @@ int process_check_result(check_result *cr)
 	source_name = check_result_source(cr);
 
 	/* trim whitespace at the end of the plugin output */
-	rstrip(cr->output);
+	if(cr->output != NULL)
+		rstrip(cr->output);
 
 	if (cr->object_check_type == SERVICE_CHECK) {
 		service *svc;


### PR DESCRIPTION
apparently the check output can be null, which makes the rstrip crash. So better check this first.