### PR TITLE
make ascii control characters in object names illegal

### DIFF
--- a/src/naemon/objects_common.c
+++ b/src/naemon/objects_common.c
@@ -3,6 +3,7 @@
 #include "nm_alloc.h"
 #include "xodtemplate.h"
 #include <string.h>
+#include <ctype.h>
 
 char *illegal_object_chars = NULL;
 
@@ -94,7 +95,7 @@ int contains_illegal_object_chars(const char *name)
 	register int x = 0;
 	register int y = 0;
 
-	if (name == NULL || illegal_object_chars == NULL)
+	if (name == NULL)
 		return FALSE;
 
 	x = (int)strlen(name) - 1;
@@ -103,8 +104,15 @@ int contains_illegal_object_chars(const char *name)
 		/* illegal user-specified characters */
 		if (illegal_object_chars != NULL)
 			for (y = 0; illegal_object_chars[y]; y++)
-				if (name[x] == illegal_object_chars[y])
+				if (name[x] == illegal_object_chars[y]) {
+					nm_log(NSLOG_CONFIG_ERROR, "Error: illegal ascii character dec(%d) at pos %d in '%s'\n", (unsigned int)name[x], x, name);
 					return TRUE;
+				}
+		/* ascii control codes are illegal */
+		if (iscntrl(name[x])) {
+			nm_log(NSLOG_CONFIG_ERROR, "Error: illegal ascii character dec(%d) at pos %d in '%s'\n", (unsigned int)name[x], x, name);
+			return TRUE;
+		}
 	}
 
 	return FALSE;

--- a/tests.mk
+++ b/tests.mk
@@ -40,7 +40,7 @@ distclean-local:
 CLEANFILES += t-tap/smallconfig/naemon.log
 EXTRA_DIST += t-tap/smallconfig/minimal.cfg t-tap/smallconfig/naemon.cfg \
 	t-tap/smallconfig/resource.cfg t-tap/smallconfig/retention.dat
-EXTRA_DIST += tests/configs/recursive tests/configs/services tests/configs/inc
+EXTRA_DIST += tests/configs/recursive tests/configs/services tests/configs/inc tests/configs/umlauts tests/configs/tabs
 EXTRA_DIST += $(dist_check_SCRIPTS)
 EXTRA_DIST += t/etc/* t/var/*
 TESTS_ENVIRONMENT = \

--- a/tests/configs/tabs/host.cfg
+++ b/tests/configs/tabs/host.cfg
@@ -1,0 +1,5 @@
+define host {
+ host_name		H	stname
+ max_check_attempts 	1
+}
+

--- a/tests/configs/tabs/naemon.cfg
+++ b/tests/configs/tabs/naemon.cfg
@@ -1,0 +1,2 @@
+log_file=foo
+cfg_file=host.cfg

--- a/tests/configs/umlauts/host.cfg
+++ b/tests/configs/umlauts/host.cfg
@@ -1,0 +1,5 @@
+define host {
+ host_name		Höstname
+ max_check_attempts 	1
+}
+

--- a/tests/configs/umlauts/naemon.cfg
+++ b/tests/configs/umlauts/naemon.cfg
@@ -1,0 +1,2 @@
+log_file=foo
+cfg_file=host.cfg

--- a/tests/test-config.c
+++ b/tests/test-config.c
@@ -102,6 +102,40 @@ START_TEST(main_include)
 }
 END_TEST
 
+START_TEST(umlauts)
+{
+	int res;
+	objcfg_files = NULL;
+	objcfg_dirs = NULL;
+	config_file_dir = nspath_absolute_dirname(TESTDIR "umlauts/naemon.cfg", NULL);
+	config_rel_path = nm_strdup(config_file_dir);
+	res = read_main_config_file(TESTDIR "umlauts/naemon.cfg");
+	ck_assert_int_eq(OK, res);
+	ck_assert(NULL != objcfg_files);
+	res = read_all_object_data(TESTDIR "umlauts/naemon.cfg");
+	ck_assert_int_eq(OK, res);
+	nm_free(config_file_dir);
+	nm_free(config_rel_path);
+}
+END_TEST
+
+START_TEST(tabs)
+{
+	int res;
+	objcfg_files = NULL;
+	objcfg_dirs = NULL;
+	config_file_dir = nspath_absolute_dirname(TESTDIR "tabs/naemon.cfg", NULL);
+	config_rel_path = nm_strdup(config_file_dir);
+	res = read_main_config_file(TESTDIR "tabs/naemon.cfg");
+	ck_assert_int_eq(OK, res);
+	ck_assert(NULL != objcfg_files);
+	res = read_all_object_data(TESTDIR "tabs/naemon.cfg");
+	ck_assert_int_eq(ERROR, res);
+	nm_free(config_file_dir);
+	nm_free(config_rel_path);
+}
+END_TEST
+
 Suite *
 config_suite(void)
 {
@@ -110,6 +144,8 @@ config_suite(void)
 	tcase_add_test(parse, recursive);
 	tcase_add_test(parse, services);
 	tcase_add_test(parse, main_include);
+	tcase_add_test(parse, umlauts);
+	tcase_add_test(parse, tabs);
 	suite_add_tcase(s, parse);
 	return s;
 }


### PR DESCRIPTION
It is a bad idea to create objects containing newlines or tabs but it's not that easy to add those characters to the illegal_object_name_chars list. So make them illegal by default.