### PR TITLE
Remove update of host and service status during the restore from retention.dat

### DIFF
--- a/src/naemon/xrddefault.c
+++ b/src/naemon/xrddefault.c
@@ -656,8 +656,6 @@ int xrddefault_read_state_information(void)
 							temp_host->acknowledgement_end_time = (time_t)0;
 						}
 					}
-					/* update host status */
-					update_host_status(temp_host, FALSE);
 				}
 
 				temp_host = NULL;
@@ -715,8 +713,6 @@ int xrddefault_read_state_information(void)
 							temp_service->acknowledgement_end_time = (time_t)0;
 						}
 					}
-					/* update service status */
-					update_service_status(temp_service, FALSE);
 				}
 
 				nm_free(host_name);


### PR DESCRIPTION
During the startup of Naemon, Naemon will first load retention data from the `retention.dat` file by calling `read_initial_state_information()`
While Naemon is processing the host and service information from the `retention.dat`, Naemon will call `update_host_status()` and `update_service_status()`.
At this point in time, Naemon has NOT loaded the downtimes from the `retention.dat` file - so the value of `scheduled_downtime_depth` is `0`.

A few nanoseconds later, Naemon will call `checks_init()`, which will call `update_host_status()` and `update_service_status()` for all hosts and services again, but this time with the correct value for `scheduled_downtime_depth`.

Instead of calling the broker modules while we are restoring the previous state from the `retation.dat`, we will now call the broker only after all information got restored.