### PR TITLE
fix pending service dependencies

### DIFF
--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -204,7 +204,7 @@ static void handle_service_check_event(struct nm_event_execution_properties *evp
 				int keep_running = FALSE;
 				switch(service_skip_check_dependency_status) {
 					case SKIP_KEEP_RUNNING_WHEN_UP:
-						if (temp_service->current_state <= STATE_WARNING) {
+						if (temp_service->current_state <= STATE_WARNING && temp_service->has_been_checked == TRUE) {
 							keep_running = TRUE;
 						}
 						break;


### PR DESCRIPTION
Having a new host with all services pending 'service_skip_check_dependency_status' does not work as expected. The idea was to keep services running until they fail to not break reporting. But only if they ever worked before. So we need to check the 'has_been_checked' flag as well.