### PR TITLE
Skip over dependencies when the current time is not within the time period

### DIFF
--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -1242,7 +1242,7 @@ int check_host_dependencies(host *hst, int dependency_type)
 		/* skip this dependency if it has a timeperiod and the current time isn't valid */
 		time(&current_time);
 		if (temp_dependency->dependency_period != NULL && check_time_against_period(current_time, temp_dependency->dependency_period_ptr) == ERROR)
-			return FALSE;
+			continue;
 
 		/* get the status to use (use last hard state if its currently in a soft state) */
 		if (temp_host->state_type == SOFT_STATE && soft_state_dependencies == FALSE)

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -1312,7 +1312,7 @@ int check_service_dependencies(service *svc, int dependency_type)
 		/* skip this dependency if it has a timeperiod and the current time isn't valid */
 		time(&current_time);
 		if (temp_dependency->dependency_period != NULL && check_time_against_period(current_time, temp_dependency->dependency_period_ptr) == ERROR)
-			return FALSE;
+			continue;
 
 		/* get the status to use (use last hard state if its currently in a soft state) */
 		if (temp_service->state_type == SOFT_STATE && soft_state_dependencies == FALSE)


### PR DESCRIPTION
If the dependency timeperiod doesn't match the current time, instead of just skipping the dependency and looking at the next one Naemon was returning from the function which bypass the dependency loop entirely

Issue #510