### PR TITLE
Check for NULL buffer in help command

### DIFF
--- a/src/naemon/query-handler.c
+++ b/src/naemon/query-handler.c
@@ -32,7 +32,7 @@ static GHashTable *qh_table;
 /* the echo service. stupid, but useful for testing */
 static int qh_echo(int sd, char *buf, unsigned int len)
 {
-	if (!strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd,
 		                 "Query handler that simply echoes back what you send it.");
 		return 0;
@@ -300,7 +300,7 @@ static int qh_help(int sd, char *buf, unsigned int len)
 {
 	struct query_handler *qh;
 
-	if (!*buf || !strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd,
 		                 "  help <name>   show help for handler <name>\n"
 		                 "  help list     list registered handlers\n");
@@ -329,7 +329,7 @@ static int qh_command(int sd, char *buf, unsigned int len)
 	char *space;
 	int mode;
 
-	if (!*buf || !strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd, "Query handler for naemon commands.\n"
 		                 "Available commands:\n"
 		                 "  run <command>     Run a command\n"


### PR DESCRIPTION
This PR fixes a potential security vulnerability in query-handler that was cloned from [{repo}](https://github.com/NagiosEnterprises/nagioscore) but did not receive the security patch.

###Details:
Affected Function: qh_echo, qh_help and qg_core in query-handler.c
Original Fix: [{original commit}](https://github.com/NagiosEnterprises/nagioscore/commit/b1a92a3b52d292ccb601e77a0b29cb1e67ac9d76)


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
[{original commit}](https://github.com/NagiosEnterprises/nagioscore/commit/b1a92a3b52d292ccb601e77a0b29cb1e67ac9d76)
[{link to original CVE/bug id}](https://nvd.nist.gov/vuln/detail/CVE-2018-13441)

Please review and merge this PR to ensure your repository is protected against this potential vulnerability