### PR TITLE
use microsecond precision for last_update

### DIFF
--- a/lib/nsutils.c
+++ b/lib/nsutils.c
@@ -1,6 +1,7 @@
 #include "lnae-utils.h"
 #include "nsutils.h"
 #include <sys/types.h>
+#include <sys/time.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -65,6 +66,28 @@ float tv_delta_f(const struct timeval *start, const struct timeval *stop)
 
 	ret += (float)((float)usecs / DIVIDER);
 	return ret;
+}
+
+/* format duration seconds into human readable string */
+const char* tv_str(struct timeval *tv) {
+	return (char *)mkstr("%lu.%06lu", tv->tv_sec, tv->tv_usec);
+}
+
+ /* Convert string to timeval */
+int str2timeval(char *str, struct timeval *tv)
+{
+	char *ptr, *ptr2;
+
+	tv->tv_sec = strtoul(str, &ptr, 10);
+	if (ptr == str) {
+		tv->tv_sec = tv->tv_usec = 0;
+		return -1;
+	}
+	if (*ptr == '.' || *ptr == ',') {
+		ptr2 = ptr + 1;
+		tv->tv_usec = strtoul(ptr2, &ptr, 10);
+	}
+	return 0;
 }
 
 #define MKSTR_BUFS 256 /* should be plenty */

--- a/lib/nsutils.h
+++ b/lib/nsutils.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <sys/types.h>
+#include <sys/time.h>
 #include <fcntl.h>
 
 NAGIOS_BEGIN_DECL
@@ -122,6 +123,43 @@ extern int tv_delta_msec(const struct timeval *start, const struct timeval *stop
  * @return time difference in fractions of seconds
  */
 extern float tv_delta_f(const struct timeval *start, const struct timeval *stop);
+
+/**
+ * clone source timestamp to destination timeval
+ * @param tv1 Destination timeval
+ * @param tv2 Source timeval
+ * @return nothing
+ */
+static inline void tv_clone(struct timeval *dst, struct timeval *src)
+{
+	dst->tv_sec = src->tv_sec;
+	dst->tv_usec = src->tv_usec;
+}
+
+/**
+ * set timestamp to target timeval
+ * @param tv Target timeval
+ * @return nothing
+ */
+static inline void tv_set(struct timeval *timestamp)
+{
+	gettimeofday(timestamp, NULL);
+}
+
+/**
+ * Convert timeval to str
+ * @param tv Source timeval
+ * @return A pointer to the formatted string on success.
+ */
+const char* tv_str(struct timeval *tv);
+
+/**
+ * Convert string to timeval
+ * @param str The timeval string (sec.usec)
+ * @param tv The target timeval
+ * @return 0 on success, -1 on errors
+ */
+extern int str2timeval(char *str, struct timeval *tv);
 
 /**
  * close and reopen stdin, stdout and stderr to /dev/null

--- a/src/naemon/broker.c
+++ b/src/naemon/broker.c
@@ -19,12 +19,6 @@ struct kvvec *get_global_store(void)
 	return &global_store;
 }
 
-/* gets timestamp for use by broker */
-static inline void get_broker_timestamp(struct timeval *timestamp)
-{
-	gettimeofday(timestamp, NULL);
-}
-
 /******************************************************************/
 /************************* EVENT FUNCTIONS ************************/
 /******************************************************************/
@@ -43,7 +37,7 @@ void broker_program_state(int type, int flags, int attr)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	/* make callbacks */
 	neb_make_callbacks(NEBCALLBACK_PROCESS_DATA, (void *)&ds);
@@ -64,7 +58,7 @@ void broker_log_data(int type, int flags, int attr, char *data, unsigned long da
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.entry_time = entry_time;
 	ds.data_type = data_type;
@@ -92,7 +86,7 @@ void broker_system_command(int type, int flags, int attr, struct timeval start_t
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.start_time = start_time;
 	ds.end_time = end_time;
@@ -138,7 +132,7 @@ int broker_event_handler(int type, int flags, int attr, int eventhandler_type, v
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.eventhandler_type = eventhandler_type;
 	if (eventhandler_type == SERVICE_EVENTHANDLER || eventhandler_type == GLOBAL_SERVICE_EVENTHANDLER) {
@@ -199,7 +193,7 @@ int broker_host_check(int type, int flags, int attr, host *hst, int check_type, 
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.host_name = hst->name;
 	ds.object_ptr = (void *)hst;
@@ -259,7 +253,7 @@ int broker_service_check(int type, int flags, int attr, service *svc, int check_
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.host_name = svc->host_name;
 	ds.service_description = svc->description;
@@ -306,7 +300,7 @@ void broker_comment_data(int type, int flags, int attr, int comment_type, int en
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.comment_type = comment_type;
 	ds.entry_type = entry_type;
@@ -341,7 +335,7 @@ void broker_downtime_data(int type, int flags, int attr, int downtime_type, char
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.downtime_type = downtime_type;
 	ds.host_name = host_name;
@@ -381,7 +375,7 @@ void broker_flapping_data(int type, int flags, int attr, int flapping_type, void
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.flapping_type = flapping_type;
 	if (flapping_type == SERVICE_FLAPPING) {
@@ -419,7 +413,7 @@ void broker_program_status(int type, int flags, int attr)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.program_start = program_start;
 	ds.pid = nagios_pid;
@@ -461,8 +455,8 @@ void broker_host_status(int type, int flags, int attr, host *hst)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
-	hst->last_update = ds.timestamp.tv_sec;
+	tv_set(&ds.timestamp);
+	tv_clone(&hst->last_update, &ds.timestamp);
 
 	ds.object_ptr = (void *)hst;
 
@@ -485,8 +479,8 @@ void broker_service_status(int type, int flags, int attr, service *svc)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
-	svc->last_update = ds.timestamp.tv_sec;
+	tv_set(&ds.timestamp);
+	tv_clone(&svc->last_update, &ds.timestamp);
 
 	ds.object_ptr = (void *)svc;
 
@@ -509,7 +503,7 @@ void broker_contact_status(int type, int flags, int attr, contact *cntct)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.object_ptr = (void *)cntct;
 
@@ -534,7 +528,7 @@ neb_cb_resultset *broker_notification_data(int type, int flags, int attr, int no
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.notification_type = notification_type;
 	ds.start_time = start_time;
@@ -578,7 +572,7 @@ int broker_contact_notification_data(int type, int flags, int attr, int notifica
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.notification_type = notification_type;
 	ds.start_time = start_time;
@@ -638,7 +632,7 @@ int broker_contact_notification_method_data(int type, int flags, int attr, int n
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.notification_type = notification_type;
 	ds.start_time = start_time;
@@ -689,7 +683,7 @@ void broker_adaptive_program_data(int type, int flags, int attr, int command_typ
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.command_type = command_type;
 	ds.modified_host_attribute = modhattr;
@@ -716,7 +710,7 @@ void broker_adaptive_host_data(int type, int flags, int attr, host *hst, int com
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.command_type = command_type;
 	ds.modified_attribute = modattr;
@@ -742,7 +736,7 @@ void broker_adaptive_service_data(int type, int flags, int attr, service *svc, i
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.command_type = command_type;
 	ds.modified_attribute = modattr;
@@ -768,7 +762,7 @@ void broker_adaptive_contact_data(int type, int flags, int attr, contact *cntct,
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.command_type = command_type;
 	ds.modified_attribute = modattr;
@@ -798,7 +792,7 @@ int broker_external_command(int type, int flags, int attr, int command_type, tim
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.command_type = command_type;
 	ds.entry_time = entry_time;
@@ -822,7 +816,7 @@ void broker_aggregated_status_data(int type, int flags, int attr)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	/* make callbacks */
 	neb_make_callbacks(NEBCALLBACK_AGGREGATED_STATUS_DATA, (void *)&ds);
@@ -843,7 +837,7 @@ void broker_retention_data(int type, int flags, int attr)
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	/* make callbacks */
 	neb_make_callbacks(NEBCALLBACK_RETENTION_DATA, (void *)&ds);
@@ -866,7 +860,7 @@ void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgem
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.acknowledgement_type = acknowledgement_type;
 	if (acknowledgement_type == SERVICE_ACKNOWLEDGEMENT) {
@@ -909,7 +903,7 @@ void broker_statechange_data(int type, int flags, int attr, int statechange_type
 	ds.type = type;
 	ds.flags = flags;
 	ds.attr = attr;
-	get_broker_timestamp(&ds.timestamp);
+	tv_set(&ds.timestamp);
 
 	ds.statechange_type = statechange_type;
 	if (statechange_type == SERVICE_STATECHANGE) {

--- a/src/naemon/commands.c
+++ b/src/naemon/commands.c
@@ -1832,14 +1832,11 @@ static int host_command_handler(const struct external_command *ext_command, time
 	unsigned long downtime_id = 0L;
 	unsigned long duration = 0L;
 	time_t old_interval = 0L;
-	time_t current_time = 0L;
 
 	if (ext_command->id != CMD_DEL_HOST_COMMENT) {
 		target_host = GV("host_name");
-		if (target_host) {
-			time(&current_time);
-			target_host->last_update = current_time;
-		}
+		if (target_host)
+			tv_set(&target_host->last_update);
 	}
 
 	switch (ext_command->id) {
@@ -2237,15 +2234,12 @@ static int service_command_handler(const struct external_command *ext_command, t
 {
 	struct service *target_service = NULL;
 	time_t old_interval = 0L;
-	time_t current_time = 0L;
 	unsigned long duration = 0L;
 
 	if (ext_command->id != CMD_DEL_SVC_COMMENT) {
 		target_service = GV_SERVICE("service");
-		if (target_service) {
-			time(&current_time);
-			target_service->last_update = current_time;
-		}
+		if (target_service)
+			tv_set(&target_service->last_update);
 	}
 
 	switch (ext_command->id) {
@@ -2558,7 +2552,6 @@ static int contactgroup_command_handler(const struct external_command *ext_comma
 
 static int change_custom_var_handler(const struct external_command *ext_command, time_t entry_time)
 {
-	time_t current_time = 0L;
 	customvariablesmember *customvariablesmember_p = NULL;
 	char *varname;
 	int x = 0;
@@ -2566,18 +2559,16 @@ static int change_custom_var_handler(const struct external_command *ext_command,
 	struct host * target_host = NULL;
 	struct contact * target_contact = NULL;
 
-	time(&current_time);
-
 	switch (ext_command->id) {
 	case CMD_CHANGE_CUSTOM_SVC_VAR:
 		target_service = GV_SERVICE("service");
-		target_service->last_update = current_time;
+		tv_set(&target_service->last_update);
 		customvariablesmember_p = target_service->custom_variables;
 		break;
 
 	case CMD_CHANGE_CUSTOM_HOST_VAR:
 		target_host = GV_HOST("host_name");
-		target_host->last_update = current_time;
+		tv_set(&target_host->last_update);
 		customvariablesmember_p = target_host->custom_variables;
 		break;
 
@@ -3537,7 +3528,7 @@ int process_passive_service_check(time_t check_time, char *host_name, char *svc_
 		cr.return_code = STATE_UNKNOWN;
 
 	/* calculate latency */
-	gettimeofday(&tv, NULL);
+	tv_set(&tv);
 	cr.latency = (double)((double)(tv.tv_sec - check_time) + (double)(tv.tv_usec / 1000.0) / 1000.0);
 	if (cr.latency < 0.0)
 		cr.latency = 0.0;
@@ -3587,7 +3578,7 @@ int process_passive_host_check(time_t check_time, char *host_name, int return_co
 	cr.return_code = return_code;
 
 	/* calculate latency */
-	gettimeofday(&tv, NULL);
+	tv_set(&tv);
 	cr.latency = (double)((double)(tv.tv_sec - check_time) + (double)(tv.tv_usec / 1000.0) / 1000.0);
 	if (cr.latency < 0.0)
 		cr.latency = 0.0;

--- a/src/naemon/logging.c
+++ b/src/naemon/logging.c
@@ -323,7 +323,7 @@ int log_debug_info(int level, int verbosity, const char *fmt, ...)
 		return ERROR;
 
 	/* write the timestamp */
-	gettimeofday(&current_time, NULL);
+	tv_set(&current_time);
 	fprintf(debug_file_fp, "[%ld.%06ld] [%03d.%d] [pid=%lu] ", (long)current_time.tv_sec, (long)current_time.tv_usec, level, verbosity, (unsigned long)getpid());
 
 	/* write the data */

--- a/src/naemon/nebmodules.h
+++ b/src/naemon/nebmodules.h
@@ -10,7 +10,7 @@ NAGIOS_BEGIN_DECL
 
 /***** MODULE VERSION INFORMATION *****/
 #define NEB_API_VERSION(x) int __neb_api_version = x;
-#define CURRENT_NEB_API_VERSION    7
+#define CURRENT_NEB_API_VERSION    8
 
 
 /***** MODULE INFORMATION *****/

--- a/src/naemon/objects_host.h
+++ b/src/naemon/objects_host.h
@@ -133,7 +133,7 @@ struct host {
 	/* objects we depend upon */
 	struct objectlist *exec_deps, *notify_deps;
 	struct objectlist *escalation_list;
-	time_t  last_update /* timestamp when object has been updated the last time */;
+	struct timeval  last_update /* timestamp when object has been updated the last time */;
 	struct  host *next;
 	struct timed_event *next_check_event;
 };

--- a/src/naemon/objects_service.h
+++ b/src/naemon/objects_service.h
@@ -124,7 +124,7 @@ struct service {
 	struct objectlist *servicegroups_ptr;
 	struct objectlist *exec_deps, *notify_deps;
 	struct objectlist *escalation_list;
-	time_t  last_update /* timestamp when object has been updated the last time */;
+	struct timeval last_update /* timestamp when object has been updated the last time */;
 	struct service *next;
 	struct timed_event *next_check_event;
 };

--- a/src/naemon/sehandlers.c
+++ b/src/naemon/sehandlers.c
@@ -242,7 +242,7 @@ static int run_global_service_event_handler(nagios_macros *mac, service *svc)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 1, "Running global event handler for service '%s' on host '%s'...\n", svc->description, svc->host_name);
 
 	/* get start time */
-	gettimeofday(&start_time, NULL);
+	tv_set(&start_time);
 
 	get_raw_command_line_r(mac, global_service_event_handler_ptr, global_service_event_handler, &raw_command, macro_options);
 	if (raw_command == NULL) {
@@ -285,7 +285,7 @@ static int run_global_service_event_handler(nagios_macros *mac, service *svc)
 		nm_log(NSLOG_EVENT_HANDLER | NSLOG_RUNTIME_WARNING, "Warning: Global service event handler command '%s' timed out after %d seconds\n", processed_command, event_handler_timeout);
 
 	/* get end time */
-	gettimeofday(&end_time, NULL);
+	tv_set(&end_time);
 
 	broker_event_handler(NEBTYPE_EVENTHANDLER_END, NEBFLAG_NONE, NEBATTR_NONE, GLOBAL_SERVICE_EVENTHANDLER, (void *)svc, svc->current_state, svc->state_type, start_time, end_time, exectime, event_handler_timeout, early_timeout, result, global_service_event_handler, processed_command, command_output);
 
@@ -324,7 +324,7 @@ static int run_service_event_handler(nagios_macros *mac, service *svc)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 1, "Running event handler for service '%s' on host '%s'...\n", svc->description, svc->host_name);
 
 	/* get start time */
-	gettimeofday(&start_time, NULL);
+	tv_set(&start_time);
 
 	get_raw_command_line_r(mac, svc->event_handler_ptr, svc->event_handler, &raw_command, macro_options);
 	if (raw_command == NULL)
@@ -366,7 +366,7 @@ static int run_service_event_handler(nagios_macros *mac, service *svc)
 		nm_log(NSLOG_EVENT_HANDLER | NSLOG_RUNTIME_WARNING, "Warning: Service event handler command '%s' timed out after %d seconds\n", processed_command, event_handler_timeout);
 
 	/* get end time */
-	gettimeofday(&end_time, NULL);
+	tv_set(&end_time);
 
 	broker_event_handler(NEBTYPE_EVENTHANDLER_END, NEBFLAG_NONE, NEBATTR_NONE, SERVICE_EVENTHANDLER, (void *)svc, svc->current_state, svc->state_type, start_time, end_time, exectime, event_handler_timeout, early_timeout, result, svc->event_handler, processed_command, command_output);
 
@@ -444,7 +444,7 @@ static int run_global_host_event_handler(nagios_macros *mac, const host *const h
 	log_debug_info(DEBUGL_EVENTHANDLERS, 1, "Running global event handler for host '%s'..\n", hst->name);
 
 	/* get start time */
-	gettimeofday(&start_time, NULL);
+	tv_set(&start_time);
 
 	get_raw_command_line_r(mac, global_host_event_handler_ptr, global_host_event_handler, &raw_command, macro_options);
 	if (raw_command == NULL)
@@ -486,7 +486,7 @@ static int run_global_host_event_handler(nagios_macros *mac, const host *const h
 		nm_log(NSLOG_EVENT_HANDLER | NSLOG_RUNTIME_WARNING, "Warning: Global host event handler command '%s' timed out after %d seconds\n", processed_command, event_handler_timeout);
 
 	/* get end time */
-	gettimeofday(&end_time, NULL);
+	tv_set(&end_time);
 
 	broker_event_handler(NEBTYPE_EVENTHANDLER_END, NEBFLAG_NONE, NEBATTR_NONE, GLOBAL_HOST_EVENTHANDLER, (void *)hst, hst->current_state, hst->state_type, start_time, end_time, exectime, event_handler_timeout, early_timeout, result, global_host_event_handler, processed_command, command_output);
 
@@ -525,7 +525,7 @@ static int run_host_event_handler(nagios_macros *mac, const host *const hst)
 	log_debug_info(DEBUGL_EVENTHANDLERS, 1, "Running event handler for host '%s'..\n", hst->name);
 
 	/* get start time */
-	gettimeofday(&start_time, NULL);
+	tv_set(&start_time);
 
 	get_raw_command_line_r(mac, hst->event_handler_ptr, hst->event_handler, &raw_command, macro_options);
 	if (raw_command == NULL)
@@ -567,7 +567,7 @@ static int run_host_event_handler(nagios_macros *mac, const host *const hst)
 		nm_log(NSLOG_EVENT_HANDLER | NSLOG_RUNTIME_WARNING, "Warning: Host event handler command '%s' timed out after %d seconds\n", processed_command, event_handler_timeout);
 
 	/* get end time */
-	gettimeofday(&end_time, NULL);
+	tv_set(&end_time);
 
 	broker_event_handler(NEBTYPE_EVENTHANDLER_END, NEBFLAG_NONE, NEBATTR_NONE, HOST_EVENTHANDLER, (void *)hst, hst->current_state, hst->state_type, start_time, end_time, exectime, event_handler_timeout, early_timeout, result, hst->event_handler, processed_command, command_output);
 

--- a/src/naemon/shared.c
+++ b/src/naemon/shared.c
@@ -68,15 +68,13 @@ void timing_point(const char *fmt, ...)
 		return;
 
 	if (first.tv_sec == 0) {
-		gettimeofday(&first, NULL);
-		last.tv_sec = first.tv_sec;
-		last.tv_usec = first.tv_usec;
+		tv_set(&first);
+		tv_clone(&last, &first);
 		printf("[0.0000 (+0.0000)] ");
 	} else {
-		gettimeofday(&now, NULL);
+		tv_set(&now);
 		printf("[%.4f (+%.4f)] ", tv_delta_f(&first, &now), tv_delta_f(&last, &now));
-		last.tv_sec = now.tv_sec;
-		last.tv_usec = now.tv_usec;
+		tv_clone(&last, &now);
 	}
 	va_start(ap, fmt);
 	vprintf(fmt, ap);

--- a/src/naemon/workers.c
+++ b/src/naemon/workers.c
@@ -163,7 +163,7 @@ static void run_job_callback(struct wproc_job *job, struct wproc_result *wpres, 
 {
 	if (!job || !job->callback)
 		return;
-	
+
 	if (!wpres) {
 		return;
 	}
@@ -288,22 +288,6 @@ void free_worker_memory(int flags)
 	workers.wps = NULL;
 	workers.len = 0;
 	workers.idx = 0;
-}
-
-static int str2timeval(char *str, struct timeval *tv)
-{
-	char *ptr, *ptr2;
-
-	tv->tv_sec = strtoul(str, &ptr, 10);
-	if (ptr == str) {
-		tv->tv_sec = tv->tv_usec = 0;
-		return -1;
-	}
-	if (*ptr == '.' || *ptr == ',') {
-		ptr2 = ptr + 1;
-		tv->tv_usec = strtoul(ptr2, &ptr, 10);
-	}
-	return 0;
 }
 
 /*

--- a/src/naemon/xrddefault.c
+++ b/src/naemon/xrddefault.c
@@ -237,7 +237,7 @@ int xrddefault_save_state_information(void)
 		fprintf(fp, "is_flapping=%d\n", temp_host->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_host->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_host->check_flapping_recovery_notification);
-		fprintf(fp, "last_update=%lu\n", temp_host->last_update);
+		fprintf(fp, "last_update=%s\n", tv_str(&temp_host->last_update));
 
 		fprintf(fp, "state_history=");
 		for (x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++)
@@ -333,7 +333,7 @@ int xrddefault_save_state_information(void)
 			fprintf(fp, "config:obsess=%d\n", conf_svc->obsess);
 			fprintf(fp, "obsess=%d\n", temp_service->obsess);
 		}
-		fprintf(fp, "last_update=%lu\n", temp_service->last_update);
+		fprintf(fp, "last_update=%s\n", tv_str(&temp_service->last_update));
 		fprintf(fp, "is_flapping=%d\n", temp_service->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_service->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_service->check_flapping_recovery_notification);
@@ -1095,7 +1095,7 @@ int xrddefault_read_state_information(void)
 						else if (!strcmp(var, "last_time_unreachable"))
 							temp_host->last_time_unreachable = strtoul(val, NULL, 10);
 						else if (!strcmp(var, "last_update"))
-							temp_host->last_update = strtoul(val, NULL, 10);
+							str2timeval(val, &temp_host->last_update);
 						else if (!strcmp(var, "notified_on_down"))
 							temp_host->notified_on |= (atoi(val) > 0 ? OPT_DOWN : 0);
 						else if (!strcmp(var, "notified_on_unreachable"))
@@ -1350,7 +1350,7 @@ int xrddefault_read_state_information(void)
 						else if (!strcmp(var, "last_time_critical"))
 							temp_service->last_time_critical = strtoul(val, NULL, 10);
 						else if (!strcmp(var, "last_update"))
-							temp_service->last_update = strtoul(val, NULL, 10);
+							str2timeval(val, &temp_service->last_update);
 						else if (!strcmp(var, "plugin_output")) {
 							nm_free(temp_service->plugin_output);
 							temp_service->plugin_output = nm_strdup(val);

--- a/src/naemon/xsddefault.c
+++ b/src/naemon/xsddefault.c
@@ -233,11 +233,10 @@ int xsddefault_save_status_data(void)
 		fprintf(fp, "\tflap_detection_enabled=%d\n", temp_host->flap_detection_enabled);
 		fprintf(fp, "\tprocess_performance_data=%d\n", temp_host->process_performance_data);
 		fprintf(fp, "\tobsess=%d\n", temp_host->obsess);
-		fprintf(fp, "\tlast_update=%lu\n", current_time);
 		fprintf(fp, "\tis_flapping=%d\n", temp_host->is_flapping);
 		fprintf(fp, "\tpercent_state_change=%.2f\n", temp_host->percent_state_change);
 		fprintf(fp, "\tscheduled_downtime_depth=%d\n", temp_host->scheduled_downtime_depth);
-		fprintf(fp, "\tlast_update=%lu\n", temp_host->last_update);
+		fprintf(fp, "\tlast_update=%s\n", tv_str(&temp_host->last_update));
 		/* custom variables */
 		for (temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if (temp_customvariablesmember->variable_name)
@@ -303,11 +302,10 @@ int xsddefault_save_status_data(void)
 		fprintf(fp, "\tflap_detection_enabled=%d\n", temp_service->flap_detection_enabled);
 		fprintf(fp, "\tprocess_performance_data=%d\n", temp_service->process_performance_data);
 		fprintf(fp, "\tobsess=%d\n", temp_service->obsess);
-		fprintf(fp, "\tlast_update=%lu\n", current_time);
 		fprintf(fp, "\tis_flapping=%d\n", temp_service->is_flapping);
 		fprintf(fp, "\tpercent_state_change=%.2f\n", temp_service->percent_state_change);
 		fprintf(fp, "\tscheduled_downtime_depth=%d\n", temp_service->scheduled_downtime_depth);
-		fprintf(fp, "\tlast_update=%lu\n", temp_service->last_update);
+		fprintf(fp, "\tlast_update=%s\n", tv_str(&temp_service->last_update));
 		/* custom variables */
 		for (temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if (temp_customvariablesmember->variable_name)

--- a/src/worker/worker.c
+++ b/src/worker/worker.c
@@ -184,7 +184,7 @@ static int finish_job(child_process *cp, int reason)
 		exit_worker(1, "Failed to init response key/value vector");
 	}
 
-	gettimeofday(&cp->ei->stop, NULL);
+	tv_set(&cp->ei->stop);
 
 	cp->ei->runtime = tv_delta_f(&cp->ei->start, &cp->ei->stop);
 
@@ -561,7 +561,7 @@ static void spawn_job(struct kvvec *kvv)
 		return;
 	}
 
-	gettimeofday(&cp->ei->start, NULL);
+	tv_set(&cp->ei->start);
 	cp->request = kvv;
 	cp->ei->timed_event = schedule_event(cp->timeout, kill_job, cp);
 	cp->outstd.buf = nm_bufferqueue_create();


### PR DESCRIPTION
Instead of integer unix timestamps, use timeval to get sub second precision for the last_update field. Other attributes ex. last_check and such still use seconds precision but might change if necessary.