### PR TITLE
rpm spec: add provides for user / group

### DIFF
--- a/naemon-core.spec
+++ b/naemon-core.spec
@@ -57,6 +57,9 @@ Requires(pre): shadow-utils
 Requires:  logrotate
 Requires:  libnaemon >= %{version}
 
+Provides: user(naemon)
+Provides: group(naemon)
+
 %description
 Naemon is an application, system and network monitoring application.
 It can escalate problems by email, pager or any other medium. It is


### PR DESCRIPTION
This pkg creates naemon user and group. Show this as "provides" in the spec file.

Trying to fix the OBS build issue:

    nothing provides user(naemon) needed by...