### PR TITLE
Remove tv_str and use a unsigned int for slot in mkstr

### DIFF
--- a/lib/nsutils.c
+++ b/lib/nsutils.c
@@ -68,11 +68,6 @@ float tv_delta_f(const struct timeval *start, const struct timeval *stop)
 	return ret;
 }
 
-/* format duration seconds into human readable string */
-const char* tv_str(struct timeval *tv) {
-	return (char *)mkstr("%lu.%06lu", tv->tv_sec, tv->tv_usec);
-}
-
  /* Convert string to timeval */
 int str2timeval(char *str, struct timeval *tv)
 {

--- a/lib/nsutils.c
+++ b/lib/nsutils.c
@@ -89,7 +89,7 @@ int str2timeval(char *str, struct timeval *tv)
 const char *mkstr(const char *fmt, ...)
 {
 	static char buf[MKSTR_BUFS][32]; /* 8k statically on the stack */
-	static int slot = 0;
+	static unsigned slot = 0;
 	char *ret;
 
 	va_list ap;

--- a/lib/nsutils.h
+++ b/lib/nsutils.h
@@ -147,13 +147,6 @@ static inline void tv_set(struct timeval *timestamp)
 }
 
 /**
- * Convert timeval to str
- * @param tv Source timeval
- * @return A pointer to the formatted string on success.
- */
-const char* tv_str(struct timeval *tv);
-
-/**
  * Convert string to timeval
  * @param str The timeval string (sec.usec)
  * @param tv The target timeval

--- a/src/naemon/xrddefault.c
+++ b/src/naemon/xrddefault.c
@@ -237,7 +237,9 @@ int xrddefault_save_state_information(void)
 		fprintf(fp, "is_flapping=%d\n", temp_host->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_host->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_host->check_flapping_recovery_notification);
-		fprintf(fp, "last_update=%s\n", tv_str(&temp_host->last_update));
+		// The (unsigned long) cast is to we don't have to worry about 32 vs 64 bit time_t.
+		fprintf(fp, "\tlast_update=%lu.%06lu\n", (unsigned long)temp_host->last_update.tv_sec, (unsigned long)temp_host->last_update.tv_usec);
+		
 
 		fprintf(fp, "state_history=");
 		for (x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++)
@@ -333,7 +335,8 @@ int xrddefault_save_state_information(void)
 			fprintf(fp, "config:obsess=%d\n", conf_svc->obsess);
 			fprintf(fp, "obsess=%d\n", temp_service->obsess);
 		}
-		fprintf(fp, "last_update=%s\n", tv_str(&temp_service->last_update));
+		// The (unsigned long) cast is to we don't have to worry about 32 vs 64 bit time_t.
+		fprintf(fp, "\tlast_update=%lu.%06lu\n", (unsigned long)temp_service->last_update.tv_sec, (unsigned long)temp_service->last_update.tv_usec);
 		fprintf(fp, "is_flapping=%d\n", temp_service->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_service->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_service->check_flapping_recovery_notification);

--- a/src/naemon/xsddefault.c
+++ b/src/naemon/xsddefault.c
@@ -236,7 +236,8 @@ int xsddefault_save_status_data(void)
 		fprintf(fp, "\tis_flapping=%d\n", temp_host->is_flapping);
 		fprintf(fp, "\tpercent_state_change=%.2f\n", temp_host->percent_state_change);
 		fprintf(fp, "\tscheduled_downtime_depth=%d\n", temp_host->scheduled_downtime_depth);
-		fprintf(fp, "\tlast_update=%s\n", tv_str(&temp_host->last_update));
+		// The (unsigned long) cast is to we don't have to worry about 32 vs 64 bit time_t.
+		fprintf(fp, "\tlast_update=%lu.%06lu\n", (unsigned long)temp_host->last_update.tv_sec, (unsigned long)temp_host->last_update.tv_usec);
 		/* custom variables */
 		for (temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if (temp_customvariablesmember->variable_name)
@@ -305,7 +306,8 @@ int xsddefault_save_status_data(void)
 		fprintf(fp, "\tis_flapping=%d\n", temp_service->is_flapping);
 		fprintf(fp, "\tpercent_state_change=%.2f\n", temp_service->percent_state_change);
 		fprintf(fp, "\tscheduled_downtime_depth=%d\n", temp_service->scheduled_downtime_depth);
-		fprintf(fp, "\tlast_update=%s\n", tv_str(&temp_service->last_update));
+		// The (unsigned long) cast is to we don't have to worry about 32 vs 64 bit time_t.
+		fprintf(fp, "\tlast_update=%lu.%06lu\n", (unsigned long)temp_service->last_update.tv_sec, (unsigned long)temp_service->last_update.tv_usec);
 		/* custom variables */
 		for (temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if (temp_customvariablesmember->variable_name)


### PR DESCRIPTION
We have noticed random segfaults on one of our systems during the creating of `status.dat`.
Since Naemon 1.5.0, `tv_str` is called in the For-loop for each host and service status object, which will increase the counter of `slot` by one each time. After 2.147.483.647 the integer will flip into -2.147.483.648 and modulo of a negativ dividend will result in a negativ value in C (and PHP, Go JavaScript).
When reading `buf[-2147468803]` whatever is at this address will be overwritten.