### PR TITLE
Fix memory corruption in mkstr caused by integer overflow

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ Breaking changes:
 Features:
 * new attribute 'check_timeout' on `host` and `service` structs, overrides the global host / service check timeouts. (#525)
 
+Bugfixes:
+* fix memory corruption in `mkstr` caused by integer overflow (#527)
+
 1.5.0 - Feb 03 2026
 ===================
 Breaking changes:

--- a/lib/nsutils.c
+++ b/lib/nsutils.c
@@ -94,7 +94,7 @@ int str2timeval(char *str, struct timeval *tv)
 const char *mkstr(const char *fmt, ...)
 {
 	static char buf[MKSTR_BUFS][32]; /* 8k statically on the stack */
-	static int slot = 0;
+	static unsigned int slot = 0;
 	char *ret;
 
 	va_list ap;

--- a/lib/nsutils.c
+++ b/lib/nsutils.c
@@ -70,7 +70,7 @@ float tv_delta_f(const struct timeval *start, const struct timeval *stop)
 
 /* format duration seconds into human readable string */
 const char* tv_str(struct timeval *tv) {
-	return (char *)mkstr("%lu.%06lu", tv->tv_sec, tv->tv_usec);
+	return (char *)mkstr("%lld.%06ld", (long long)tv->tv_sec, (long)tv->tv_usec);
 }
 
  /* Convert string to timeval */


### PR DESCRIPTION
We have noticed random segfaults on one of our systems during the creating of `status.dat`.
Since Naemon 1.5.0, `tv_str` is called in the For-loop for each host and service status object, which will increase the counter of slot by one each time. After `2.147.483.647` the integer will flip into `-2.147.483.648` and modulo of a negativ dividend will result in a negativ value in C (and PHP, Go JavaScript).
When reading `buf[-2147468803]` whatever is at this address will be overwritten.

This is a stripped down version of https://github.com/naemon/naemon-core/pull/526 which will keep the `tv_str` method as the issue was within the underlying `mkstr`.

---
Some thoughts and discoveries:
I would suggest to replace `tv_str` with a version which will not depend on a rolling buffer like so

```C
/* format duration seconds into human readable string */
void tv_str_r(const struct timeval *tv, char *buf, size_t buflen) {
    snprintf(buf, buflen, "%lu.%06lu", (unsigned long)tv->tv_sec, (unsigned long)tv->tv_usec);
}
```

```C
char buf[32];
tv_str_r(&tv, buf, sizeof(buf));
printf("Time: %s\n", buf);
/* No free required if the buffer is allocated by the caller on the stack */
```

Also `fprintf` can do this as well
```C
// The (unsigned long) cast is so we don't have to worry about 32 vs 64 bit time_t.
fprintf(fp, "\tlast_update=%lu.%06lu\n", (unsigned long)temp_service->last_update.tv_sec, (unsigned long)temp_service->last_update.tv_usec);
```

In addition, `mkstr` is not thread-safe which is irrelevant for Naemon, but could be relevant when a broker module with threads is the caller. To resolve this, we could use the `__thread` keyword like so
```C
#define MKSTR_BUFS 256 /* should be plenty */
const char *mkstr(const char *fmt, ...)
{
	static __thread char buf[MKSTR_BUFS][32]; /* 8k statically on the stack */
	static __thread unsigned int slot = 0;
	char *ret;

	va_list ap;
	va_start(ap, fmt);
	ret = buf[slot++ % MKSTR_BUFS];
	vsnprintf(ret, sizeof(buf[0]), fmt, ap);
	va_end(ap);
	return ret;
}
```

In this case, we have to link `pthread` as well in the `Makefile.am`
For all binaries
```
LDADD = libnaemon.la $(GLIB_LIBS) -lm -ldl -lpthread
```

Or only for Naemon
```
src_naemon_naemon_LDFLAGS = -rdynamic -lpthread
```
