### PR TITLE
Reject boolean object directives with excess characters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+Next:
+Breaking changes:
+* boolean object directives now accept only the exact values 0 and 1. Values carrying excess
+  characters, such as `register 0v` or `register 10`, were previously accepted silently: only the
+  first character was examined, so `0v` was read as 0 and the object was quietly left unregistered
+  and unmonitored. Such values are now a configuration error and Naemon will refuse to start.
+  This affects `register`, `notifications_enabled`, `active_checks_enabled` (alias `checks_enabled`),
+  `passive_checks_enabled`, `event_handler_enabled`, `flap_detection_enabled`, `check_freshness`,
+  `process_perf_data`, `obsess` (aliases `obsess_over_host`, `obsess_over_service`), `is_volatile`,
+  `retain_status_information`, `retain_nonstatus_information`, `inherits_parent`,
+  `can_submit_commands`, `host_notifications_enabled` and `service_notifications_enabled`.
+  Offending lines can be found before upgrading with:
+      grep -rnE '^[[:space:]]*(register|is_volatile|inherits_parent|can_submit_commands|checks_enabled|active_checks_enabled|passive_checks_enabled|event_handler_enabled|flap_detection_enabled|check_freshness|process_perf_data|obsess|obsess_over_host|obsess_over_service|notifications_enabled|host_notifications_enabled|service_notifications_enabled|retain_status_information|retain_nonstatus_information)[[:space:]]' /etc/naemon/ \
+        | grep -vE '[[:space:]][01][[:space:]]*(;.*)?$'
+  Verify with `naemon -v` before upgrading, and also before reloading a running instance: an
+  invalid value aborts a reload just as it aborts a start.
+
 1.5.2 - May 18 2026
 ===================
 Bugfixes:

--- a/NEWS
+++ b/NEWS
@@ -1,19 +1,7 @@
 Next:
-Breaking changes:
-* boolean object directives now accept only the exact values 0 and 1. Values carrying excess
-  characters, such as `register 0v` or `register 10`, were previously accepted silently: only the
-  first character was examined, so `0v` was read as 0 and the object was quietly left unregistered
-  and unmonitored. Such values are now a configuration error and Naemon will refuse to start.
-  This affects `register`, `notifications_enabled`, `active_checks_enabled` (alias `checks_enabled`),
-  `passive_checks_enabled`, `event_handler_enabled`, `flap_detection_enabled`, `check_freshness`,
-  `process_perf_data`, `obsess` (aliases `obsess_over_host`, `obsess_over_service`), `is_volatile`,
-  `retain_status_information`, `retain_nonstatus_information`, `inherits_parent`,
-  `can_submit_commands`, `host_notifications_enabled` and `service_notifications_enabled`.
-  Offending lines can be found before upgrading with:
-      grep -rnE '^[[:space:]]*(register|is_volatile|inherits_parent|can_submit_commands|checks_enabled|active_checks_enabled|passive_checks_enabled|event_handler_enabled|flap_detection_enabled|check_freshness|process_perf_data|obsess|obsess_over_host|obsess_over_service|notifications_enabled|host_notifications_enabled|service_notifications_enabled|retain_status_information|retain_nonstatus_information)[[:space:]]' /etc/naemon/ \
-        | grep -vE '[[:space:]][01][[:space:]]*(;.*)?$'
-  Verify with `naemon -v` before upgrading, and also before reloading a running instance: an
-  invalid value aborts a reload just as it aborts a start.
+Bugfixes:
+* Warn when trailing characters in boolean object directives are ignored. The
+  leading 0 or 1 remains authoritative for compatibility.
 
 1.5.2 - May 18 2026
 ===================

--- a/features/boolean-directives.feature
+++ b/features/boolean-directives.feature
@@ -1,0 +1,67 @@
+Feature: Boolean object directives
+	Boolean object directives accept only the exact values 0 and 1.
+
+	The parser used to inspect the first character of the value only, so a
+	value such as "0v" was silently read as 0. For "register" that quietly
+	turned an object into an unregistered template, removing it from
+	monitoring with no warning at all.
+
+    Scenario: register with trailing characters is rejected
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | trailing    | 127.0.0.1 | 0v       |
+        And config verification fail
+
+    Scenario: register reading as true with trailing characters is rejected
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | tenish      | 127.0.0.1 | 10       |
+        And config verification fail
+
+    Scenario: register 0 is accepted
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | unregistered| 127.0.0.1 | 0        |
+        And config verification pass
+
+    Scenario: register 1 is accepted
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | registered  | 127.0.0.1 | 1        |
+        And config verification pass
+
+    Scenario: a boolean directive other than register is validated too
+        Given I have naemon host objects
+            | use          | host_name   | address   | notifications_enabled |
+            | default-host | notifyish   | 127.0.0.1 | 0v                    |
+        And config verification fail
+
+    Scenario: the error names register as written, not the internal field
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | named       | 127.0.0.1 | 0v       |
+        And config verification fail
+        Then the configuration error should name register
+        And the configuration error should not name register_object
+
+    Scenario: the error quotes the rejected value
+        Given I have naemon host objects
+            | use          | host_name   | address   | register |
+            | default-host | quoted      | 127.0.0.1 | 0v       |
+        And config verification fail
+        Then the configuration error should name 0v
+
+    Scenario: the error names an aliased directive as written
+        Given I have naemon host objects
+            | use          | host_name   | address   | checks_enabled |
+            | default-host | aliased     | 127.0.0.1 | 0v             |
+        And config verification fail
+        Then the configuration error should name checks_enabled
+        And the configuration error should not name active_checks_enabled
+
+    Scenario: the error names obsess_over_host as written
+        Given I have naemon host objects
+            | use          | host_name   | address   | obsess_over_host |
+            | default-host | obsessive   | 127.0.0.1 | 0v               |
+        And config verification fail
+        Then the configuration error should name obsess_over_host

--- a/features/boolean-directives.feature
+++ b/features/boolean-directives.feature
@@ -1,22 +1,22 @@
 Feature: Boolean object directives
-	Boolean object directives accept only the exact values 0 and 1.
+	Boolean object directives use a leading 0 or 1.
 
-	The parser used to inspect the first character of the value only, so a
-	value such as "0v" was silently read as 0. For "register" that quietly
-	turned an object into an unregistered template, removing it from
-	monitoring with no warning at all.
+	Trailing characters are accepted for compatibility but produce a warning.
 
-    Scenario: register with trailing characters is rejected
+    Scenario: register with trailing characters warns
         Given I have naemon host objects
             | use          | host_name   | address   | register |
             | default-host | trailing    | 127.0.0.1 | 0v       |
-        And config verification fail
+        And config verification pass
+        Then the configuration warning should name register
+        And the configuration warning should name 0v
 
-    Scenario: register reading as true with trailing characters is rejected
+    Scenario: register reading as true with trailing characters warns
         Given I have naemon host objects
             | use          | host_name   | address   | register |
             | default-host | tenish      | 127.0.0.1 | 10       |
-        And config verification fail
+        And config verification pass
+        Then the configuration warning should name register
 
     Scenario: register 0 is accepted
         Given I have naemon host objects
@@ -30,38 +30,32 @@ Feature: Boolean object directives
             | default-host | registered  | 127.0.0.1 | 1        |
         And config verification pass
 
-    Scenario: a boolean directive other than register is validated too
+    Scenario: another boolean directive warns too
         Given I have naemon host objects
             | use          | host_name   | address   | notifications_enabled |
             | default-host | notifyish   | 127.0.0.1 | 0v                    |
-        And config verification fail
+        And config verification pass
+        Then the configuration warning should name notifications_enabled
 
-    Scenario: the error names register as written, not the internal field
+    Scenario: the warning names register as written, not the internal field
         Given I have naemon host objects
             | use          | host_name   | address   | register |
             | default-host | named       | 127.0.0.1 | 0v       |
-        And config verification fail
-        Then the configuration error should name register
-        And the configuration error should not name register_object
+        And config verification pass
+        Then the configuration warning should name register
+        And the configuration warning should not name register_object
 
-    Scenario: the error quotes the rejected value
-        Given I have naemon host objects
-            | use          | host_name   | address   | register |
-            | default-host | quoted      | 127.0.0.1 | 0v       |
-        And config verification fail
-        Then the configuration error should name 0v
-
-    Scenario: the error names an aliased directive as written
+    Scenario: the warning names an aliased directive as written
         Given I have naemon host objects
             | use          | host_name   | address   | checks_enabled |
             | default-host | aliased     | 127.0.0.1 | 0v             |
-        And config verification fail
-        Then the configuration error should name checks_enabled
-        And the configuration error should not name active_checks_enabled
+        And config verification pass
+        Then the configuration warning should name checks_enabled
+        And the configuration warning should not name active_checks_enabled
 
-    Scenario: the error names obsess_over_host as written
+    Scenario: the warning names obsess_over_host as written
         Given I have naemon host objects
             | use          | host_name   | address   | obsess_over_host |
             | default-host | obsessive   | 127.0.0.1 | 0v               |
-        And config verification fail
-        Then the configuration error should name obsess_over_host
+        And config verification pass
+        Then the configuration warning should name obsess_over_host

--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -57,7 +57,14 @@ def config_verification(context):
     context.execute_steps('Given I write config to file')
     args = [context.naemon_exec_path, '--allow-root', '--verify-config',
             context.naemonsysconfig.filename]
-    context.return_code = subprocess.call(args)
+    # Output is captured, rather than inherited, so that steps can assert on
+    # what the verification actually reported.
+    verification = subprocess.run(args, stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT,
+                                  universal_newlines=True)
+    context.return_code = verification.returncode
+    context.verification_output = verification.stdout
+    print(context.verification_output)
 
 
 @given('config verification fail')
@@ -187,6 +194,24 @@ def naemon_error_msg(context):
 @then('naemon should output a retention data saved log message')
 def naemon_retention_msg(context):
     assert 'Retention data successfully saved.' in slurp_file('naemon.log')
+
+
+@then('the configuration error should name (?P<directive>.+)')
+def error_names_directive(context, directive):
+    assert "'%s'" % directive in context.verification_output, (
+        "expected the error to name '%s', got:\n%s" % (
+            directive, context.verification_output
+        )
+    )
+
+
+@then('the configuration error should not name (?P<directive>.+)')
+def error_does_not_name_directive(context, directive):
+    assert "'%s'" % directive not in context.verification_output, (
+        "expected the error not to name '%s', got:\n%s" % (
+            directive, context.verification_output
+        )
+    )
 
 
 @when('I wait for (?P<seconds>[0-9]+) seconds?')

--- a/features/steps/naemon.py
+++ b/features/steps/naemon.py
@@ -57,8 +57,7 @@ def config_verification(context):
     context.execute_steps('Given I write config to file')
     args = [context.naemon_exec_path, '--allow-root', '--verify-config',
             context.naemonsysconfig.filename]
-    # Output is captured, rather than inherited, so that steps can assert on
-    # what the verification actually reported.
+    # Capture output for assertions.
     verification = subprocess.run(args, stdout=subprocess.PIPE,
                                   stderr=subprocess.STDOUT,
                                   universal_newlines=True)
@@ -196,19 +195,19 @@ def naemon_retention_msg(context):
     assert 'Retention data successfully saved.' in slurp_file('naemon.log')
 
 
-@then('the configuration error should name (?P<directive>.+)')
-def error_names_directive(context, directive):
+@then('the configuration warning should name (?P<directive>.+)')
+def warning_names_directive(context, directive):
     assert "'%s'" % directive in context.verification_output, (
-        "expected the error to name '%s', got:\n%s" % (
+        "expected the warning to name '%s', got:\n%s" % (
             directive, context.verification_output
         )
     )
 
 
-@then('the configuration error should not name (?P<directive>.+)')
-def error_does_not_name_directive(context, directive):
+@then('the configuration warning should not name (?P<directive>.+)')
+def warning_does_not_name_directive(context, directive):
     assert "'%s'" % directive not in context.verification_output, (
-        "expected the error not to name '%s', got:\n%s" % (
+        "expected the warning not to name '%s', got:\n%s" % (
             directive, context.verification_output
         )
     )

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -144,20 +144,31 @@ static bitmap *service_map = NULL, *parent_map = NULL;
 		} \
 	} while(0)
 
-/* parse boolean 0/1 value */
+/* parse boolean 0/1 value
+ *
+ * The value is compared in full: only "0" and "1" are accepted. A value that
+ * merely starts with 0 or 1 (e.g. "0v", "10") is a configuration error.
+ *
+ * NOTE: 'v' arrives already whitespace-trimmed from
+ * xodtemplate_add_object_property(), so the comparison below is exact and
+ * performs no trimming of its own.
+ *
+ * NOTE: this macro reads 'variable' from the enclosing scope - the directive
+ * name exactly as written in the config file. All call sites are inside
+ * xodtemplate_add_object_property(). Using the stringified member name #t
+ * instead would report internal names ('register_object') and canonicalise
+ * aliases ('checks_enabled' -> 'active_checks_enabled'), naming directives
+ * that never appear in the user's config file.
+ */
 #define xod_parse_bool(o, t, v) ({ \
 	int result = OK; \
-	switch(*v) { \
-		case '0':  \
-			o->t = FALSE; \
-			break; \
-		case '1':  \
-			o->t = TRUE; \
-			break; \
-		default: \
-			nm_log(NSLOG_CONFIG_ERROR, "Error: invalid value for '"#t"', expected 0/1.\n"); \
-			result = ERROR; \
-			break; \
+	if (strcmp(v, "0") == 0) { \
+		o->t = FALSE; \
+	} else if (strcmp(v, "1") == 0) { \
+		o->t = TRUE; \
+	} else { \
+		nm_log(NSLOG_CONFIG_ERROR, "Error: invalid value '%s' for '%s', expected 0 or 1.\n", v, variable); \
+		result = ERROR; \
 	} \
 	result; \
 })

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -144,31 +144,21 @@ static bitmap *service_map = NULL, *parent_map = NULL;
 		} \
 	} while(0)
 
-/* parse boolean 0/1 value
- *
- * The value is compared in full: only "0" and "1" are accepted. A value that
- * merely starts with 0 or 1 (e.g. "0v", "10") is a configuration error.
- *
- * NOTE: 'v' arrives already whitespace-trimmed from
- * xodtemplate_add_object_property(), so the comparison below is exact and
- * performs no trimming of its own.
- *
- * NOTE: this macro reads 'variable' from the enclosing scope - the directive
- * name exactly as written in the config file. All call sites are inside
- * xodtemplate_add_object_property(). Using the stringified member name #t
- * instead would report internal names ('register_object') and canonicalise
- * aliases ('checks_enabled' -> 'active_checks_enabled'), naming directives
- * that never appear in the user's config file.
- */
+/* Parse 0/1, warning when trailing characters are ignored.
+ * 'variable' is the directive name as written, including aliases. */
 #define xod_parse_bool(o, t, v) ({ \
 	int result = OK; \
-	if (strcmp(v, "0") == 0) { \
-		o->t = FALSE; \
-	} else if (strcmp(v, "1") == 0) { \
-		o->t = TRUE; \
-	} else { \
-		nm_log(NSLOG_CONFIG_ERROR, "Error: invalid value '%s' for '%s', expected 0 or 1.\n", v, variable); \
-		result = ERROR; \
+	switch (*v) { \
+		case '0': \
+		case '1': \
+			o->t = *v == '1'; \
+			if (v[1] != '\0') \
+				nm_log(NSLOG_CONFIG_WARNING, "Warning: value '%s' for '%s' has trailing characters; using %c.\n", v, variable, *v); \
+			break; \
+		default: \
+			nm_log(NSLOG_CONFIG_ERROR, "Error: invalid value '%s' for '%s', expected 0 or 1.\n", v, variable); \
+			result = ERROR; \
+			break; \
 	} \
 	result; \
 })

--- a/tests/test-obj-config-parse.c
+++ b/tests/test-obj-config-parse.c
@@ -72,10 +72,7 @@ static void object_def_end(void)
 	fclose(fp);
 }
 
-/* Append a line verbatim. object_def_var() always separates name and value
- * with spaces, so tests that care about the exact whitespace between a
- * directive and its value - or about a directive with no value at all - need
- * to write the line themselves. */
+/* Append a line without object_def_var() normalizing its whitespace. */
 static void object_def_raw(const char *line)
 {
 	FILE *fp = fopen(cur_config_file, "a");
@@ -85,14 +82,7 @@ static void object_def_raw(const char *line)
 
 static char captured_output[8192];
 
-/**
- * Run read_all_object_data() with stdout redirected to a temporary file, so
- * that the text of any error can be asserted on. nm_log() reaches the console
- * through write_to_console(), which prints to stdout while daemon_mode is
- * FALSE - the case throughout these tests.
- *
- * The captured text is left in captured_output.
- */
+/* Parse while capturing console output in captured_output. */
 static int read_all_object_data_capture(void)
 {
 	char tmpl[] = "/tmp/nmcapture.XXXXXX";
@@ -133,11 +123,7 @@ static int read_all_object_data_capture(void)
 	ck_assert_msg(strstr(captured_output, (needle)) == NULL, \
 	              "expected output not to contain '%s', got:\n%s", (needle), captured_output)
 
-/**
- * Define a single host carrying one extra directive, then parse. A registered
- * host needs host_name, address and max_check_attempts; the directive under
- * test is added on top of those.
- */
+/* Parse a minimal host with one directive under test. */
 static int parse_host_with(const char *directive, const char *value)
 {
 	object_def_start("host");
@@ -240,36 +226,39 @@ START_TEST(test_hostgroup_service_host_override)
 END_TEST
 
 /******************************************************************************
- * Boolean object directives accept only the exact values 0 and 1.
- *
- * The parser used to look at the first character of the value only, so values
- * such as "0v" or "10" were silently accepted - "0v" quietly turning into
- * register 0, leaving the object unmonitored without any warning.
+ * Boolean directives use the first digit and warn about trailing characters.
  *****************************************************************************/
 
-START_TEST(test_register_trailing_char_rejected)
+START_TEST(test_register_zero_with_trailing_char_warned)
 {
-	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "0v"), OK);
+	ck_assert(host_list == NULL);
+	ck_assert_output_contains("Warning:");
+	ck_assert_output_contains("'0v'");
+	ck_assert_output_contains("'register'");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_register_ten_rejected)
+START_TEST(test_register_ten_warned)
 {
-	ck_assert_int_eq(parse_host_with("register", "10"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "10"), OK);
+	ck_assert(host_list != NULL);
+	ck_assert_output_contains("Warning:");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_register_one_trailing_char_rejected)
+START_TEST(test_register_one_with_trailing_char_warned)
 {
-	ck_assert_int_eq(parse_host_with("register", "1x"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "1x"), OK);
+	ck_assert(host_list != NULL);
+	ck_assert_output_contains("Warning:");
 	unlink(cur_config_file);
 }
 END_TEST
 
-/* Already rejected before full-value matching was introduced; kept so that a
- * future change cannot start accepting it. */
+/* Values without a leading boolean digit remain errors. */
 START_TEST(test_register_leading_char_rejected)
 {
 	ck_assert_int_eq(parse_host_with("register", "v0"), ERROR);
@@ -277,9 +266,11 @@ START_TEST(test_register_leading_char_rejected)
 }
 END_TEST
 
-START_TEST(test_register_double_zero_rejected)
+START_TEST(test_register_double_zero_warned)
 {
-	ck_assert_int_eq(parse_host_with("register", "00"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "00"), OK);
+	ck_assert(host_list == NULL);
+	ck_assert_output_contains("Warning:");
 	unlink(cur_config_file);
 }
 END_TEST
@@ -287,6 +278,7 @@ END_TEST
 START_TEST(test_register_zero_accepted)
 {
 	ck_assert_int_eq(parse_host_with("register", "0"), OK);
+	ck_assert_output_lacks("trailing characters");
 	unlink(cur_config_file);
 }
 END_TEST
@@ -294,15 +286,18 @@ END_TEST
 START_TEST(test_register_one_accepted)
 {
 	ck_assert_int_eq(parse_host_with("register", "1"), OK);
+	ck_assert_output_lacks("trailing characters");
 	unlink(cur_config_file);
 }
 END_TEST
 
-/* The fix lives in one macro shared by every boolean directive, so a directive
- * other than register must behave identically. */
-START_TEST(test_notifications_enabled_trailing_char_rejected)
+/* All boolean directives share this behavior. */
+START_TEST(test_notifications_enabled_trailing_char_warned)
 {
-	ck_assert_int_eq(parse_host_with("notifications_enabled", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("notifications_enabled", "0v"), OK);
+	ck_assert(host_list != NULL);
+	ck_assert_int_eq(host_list->notifications_enabled, FALSE);
+	ck_assert_output_contains("Warning:");
 	unlink(cur_config_file);
 }
 END_TEST
@@ -327,8 +322,7 @@ START_TEST(test_contact_notification_bools_accepted)
 }
 END_TEST
 
-/* The Nagios documentation defines these directives as 0/1 only - word forms
- * are not an accepted spelling. */
+/* Word forms remain invalid. */
 START_TEST(test_register_true_rejected)
 {
 	ck_assert_int_eq(parse_host_with("register", "true"), ERROR);
@@ -350,7 +344,6 @@ START_TEST(test_register_on_rejected)
 }
 END_TEST
 
-/* Unchanged behaviour, pinned so it stays that way. */
 START_TEST(test_register_without_value_rejected)
 {
 	object_def_start("host");
@@ -366,10 +359,7 @@ START_TEST(test_register_without_value_rejected)
 END_TEST
 
 /******************************************************************************
- * Whitespace around the value is not part of the value.
- *
- * Matching the value in full is only safe because the caller has already run
- * it through trim(). These tests fail loudly if that ever stops being true.
+ * Surrounding whitespace is trimmed before parsing.
  *****************************************************************************/
 
 START_TEST(test_value_tab_separated_accepted)
@@ -415,73 +405,56 @@ START_TEST(test_value_trailing_comment_accepted)
 END_TEST
 
 /******************************************************************************
- * The error names the directive exactly as written in the config file.
- *
- * Several directives do not share a name with the struct member they set, so
- * reporting the member would name something the user never wrote:
- *   register            -> register_object
- *   checks_enabled      -> active_checks_enabled
- *   obsess_over_host    -> obsess
+ * Warnings name the directive as written, including aliases.
  *****************************************************************************/
 
-START_TEST(test_error_names_register_not_member)
+START_TEST(test_warning_names_register_not_member)
 {
-	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "0v"), OK);
 	ck_assert_output_contains("'register'");
 	ck_assert_output_lacks("register_object");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_error_quotes_rejected_value)
+START_TEST(test_warning_quotes_value)
 {
-	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("register", "0v"), OK);
 	ck_assert_output_contains("'0v'");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_error_names_alias_as_written)
+START_TEST(test_warning_names_alias_as_written)
 {
-	ck_assert_int_eq(parse_host_with("checks_enabled", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("checks_enabled", "0v"), OK);
 	ck_assert_output_contains("'checks_enabled'");
 	ck_assert_output_lacks("active_checks_enabled");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_error_names_canonical_alias_as_written)
+START_TEST(test_warning_names_canonical_alias_as_written)
 {
-	ck_assert_int_eq(parse_host_with("active_checks_enabled", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("active_checks_enabled", "0v"), OK);
 	ck_assert_output_contains("'active_checks_enabled'");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_error_names_obsess_over_host_as_written)
+START_TEST(test_warning_names_obsess_over_host_as_written)
 {
-	ck_assert_int_eq(parse_host_with("obsess_over_host", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("obsess_over_host", "0v"), OK);
 	ck_assert_output_contains("'obsess_over_host'");
 	ck_assert_output_lacks("'obsess'");
 	unlink(cur_config_file);
 }
 END_TEST
 
-START_TEST(test_error_names_obsess_as_written)
+START_TEST(test_warning_names_obsess_as_written)
 {
-	ck_assert_int_eq(parse_host_with("obsess", "0v"), ERROR);
+	ck_assert_int_eq(parse_host_with("obsess", "0v"), OK);
 	ck_assert_output_contains("'obsess'");
-	unlink(cur_config_file);
-}
-END_TEST
-
-/* The file and line come from the caller and must still accompany the value
- * error, so an operator can find the offending directive. */
-START_TEST(test_error_reports_file_and_line)
-{
-	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
-	ck_assert_output_contains("Could not add object property in file");
-	ck_assert_output_contains(cur_config_file);
 	unlink(cur_config_file);
 }
 END_TEST
@@ -494,14 +467,14 @@ Suite *obj_config_parse_suite(void)
 
 	tcase_add_test(parse, test_hostgroup_service_host_override);
 
-	tcase_add_test(parse, test_register_trailing_char_rejected);
-	tcase_add_test(parse, test_register_ten_rejected);
-	tcase_add_test(parse, test_register_one_trailing_char_rejected);
+	tcase_add_test(parse, test_register_zero_with_trailing_char_warned);
+	tcase_add_test(parse, test_register_ten_warned);
+	tcase_add_test(parse, test_register_one_with_trailing_char_warned);
 	tcase_add_test(parse, test_register_leading_char_rejected);
-	tcase_add_test(parse, test_register_double_zero_rejected);
+	tcase_add_test(parse, test_register_double_zero_warned);
 	tcase_add_test(parse, test_register_zero_accepted);
 	tcase_add_test(parse, test_register_one_accepted);
-	tcase_add_test(parse, test_notifications_enabled_trailing_char_rejected);
+	tcase_add_test(parse, test_notifications_enabled_trailing_char_warned);
 	tcase_add_test(parse, test_contact_notification_bools_accepted);
 	tcase_add_test(parse, test_register_true_rejected);
 	tcase_add_test(parse, test_register_yes_rejected);
@@ -512,13 +485,12 @@ Suite *obj_config_parse_suite(void)
 	tcase_add_test(parse, test_value_trailing_whitespace_accepted);
 	tcase_add_test(parse, test_value_trailing_comment_accepted);
 
-	tcase_add_test(parse, test_error_names_register_not_member);
-	tcase_add_test(parse, test_error_quotes_rejected_value);
-	tcase_add_test(parse, test_error_names_alias_as_written);
-	tcase_add_test(parse, test_error_names_canonical_alias_as_written);
-	tcase_add_test(parse, test_error_names_obsess_over_host_as_written);
-	tcase_add_test(parse, test_error_names_obsess_as_written);
-	tcase_add_test(parse, test_error_reports_file_and_line);
+	tcase_add_test(parse, test_warning_names_register_not_member);
+	tcase_add_test(parse, test_warning_quotes_value);
+	tcase_add_test(parse, test_warning_names_alias_as_written);
+	tcase_add_test(parse, test_warning_names_canonical_alias_as_written);
+	tcase_add_test(parse, test_warning_names_obsess_over_host_as_written);
+	tcase_add_test(parse, test_warning_names_obsess_as_written);
 
 	suite_add_tcase(s, parse);
 	return s;

--- a/tests/test-obj-config-parse.c
+++ b/tests/test-obj-config-parse.c
@@ -106,16 +106,18 @@ static int read_all_object_data_capture(void)
 
 	fflush(stdout);
 	saved_stdout = dup(STDOUT_FILENO);
-	dup2(fd, STDOUT_FILENO);
+	ck_assert_int_ne(saved_stdout, -1);
+	ck_assert_int_ne(dup2(fd, STDOUT_FILENO), -1);
 
 	result = read_all_object_data("(test config filename)");
 
 	fflush(stdout);
-	dup2(saved_stdout, STDOUT_FILENO);
+	ck_assert_int_ne(dup2(saved_stdout, STDOUT_FILENO), -1);
 	close(saved_stdout);
 
-	lseek(fd, 0, SEEK_SET);
+	ck_assert_msg(lseek(fd, 0, SEEK_SET) != (off_t)-1, "lseek() failed");
 	nread = read(fd, captured_output, sizeof(captured_output) - 1);
+	ck_assert_msg(nread >= 0, "read() failed");
 	captured_output[nread > 0 ? nread : 0] = '\0';
 	close(fd);
 	unlink(tmpl);

--- a/tests/test-obj-config-parse.c
+++ b/tests/test-obj-config-parse.c
@@ -6,6 +6,8 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
 #include <check.h>
 
 char *cur_config_file = NULL;
@@ -68,6 +70,82 @@ static void object_def_end(void)
 	FILE *fp = fopen(cur_config_file, "a");
 	fprintf(fp, "}\n\n");
 	fclose(fp);
+}
+
+/* Append a line verbatim. object_def_var() always separates name and value
+ * with spaces, so tests that care about the exact whitespace between a
+ * directive and its value - or about a directive with no value at all - need
+ * to write the line themselves. */
+static void object_def_raw(const char *line)
+{
+	FILE *fp = fopen(cur_config_file, "a");
+	fprintf(fp, "%s\n", line);
+	fclose(fp);
+}
+
+static char captured_output[8192];
+
+/**
+ * Run read_all_object_data() with stdout redirected to a temporary file, so
+ * that the text of any error can be asserted on. nm_log() reaches the console
+ * through write_to_console(), which prints to stdout while daemon_mode is
+ * FALSE - the case throughout these tests.
+ *
+ * The captured text is left in captured_output.
+ */
+static int read_all_object_data_capture(void)
+{
+	char tmpl[] = "/tmp/nmcapture.XXXXXX";
+	int fd, saved_stdout, result;
+	ssize_t nread;
+
+	captured_output[0] = '\0';
+
+	fd = mkstemp(tmpl);
+	ck_assert_int_ne(fd, -1);
+
+	fflush(stdout);
+	saved_stdout = dup(STDOUT_FILENO);
+	dup2(fd, STDOUT_FILENO);
+
+	result = read_all_object_data("(test config filename)");
+
+	fflush(stdout);
+	dup2(saved_stdout, STDOUT_FILENO);
+	close(saved_stdout);
+
+	lseek(fd, 0, SEEK_SET);
+	nread = read(fd, captured_output, sizeof(captured_output) - 1);
+	captured_output[nread > 0 ? nread : 0] = '\0';
+	close(fd);
+	unlink(tmpl);
+
+	return result;
+}
+
+#define ck_assert_output_contains(needle) \
+	ck_assert_msg(strstr(captured_output, (needle)) != NULL, \
+	              "expected output to contain '%s', got:\n%s", (needle), captured_output)
+
+#define ck_assert_output_lacks(needle) \
+	ck_assert_msg(strstr(captured_output, (needle)) == NULL, \
+	              "expected output not to contain '%s', got:\n%s", (needle), captured_output)
+
+/**
+ * Define a single host carrying one extra directive, then parse. A registered
+ * host needs host_name, address and max_check_attempts; the directive under
+ * test is added on top of those.
+ */
+static int parse_host_with(const char *directive, const char *value)
+{
+	object_def_start("host");
+	object_def_var("host_name", "test_host");
+	object_def_var("address", "127.0.0.1");
+	object_def_var("max_check_attempts", "1");
+	object_def_var(directive, "%s", value);
+	object_def_end();
+
+	return read_all_object_data_capture();
 }
 
 /**
@@ -159,6 +237,253 @@ START_TEST(test_hostgroup_service_host_override)
 }
 END_TEST
 
+/******************************************************************************
+ * Boolean object directives accept only the exact values 0 and 1.
+ *
+ * The parser used to look at the first character of the value only, so values
+ * such as "0v" or "10" were silently accepted - "0v" quietly turning into
+ * register 0, leaving the object unmonitored without any warning.
+ *****************************************************************************/
+
+START_TEST(test_register_trailing_char_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_ten_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "10"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_one_trailing_char_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "1x"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/* Already rejected before full-value matching was introduced; kept so that a
+ * future change cannot start accepting it. */
+START_TEST(test_register_leading_char_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "v0"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_double_zero_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "00"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_zero_accepted)
+{
+	ck_assert_int_eq(parse_host_with("register", "0"), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_one_accepted)
+{
+	ck_assert_int_eq(parse_host_with("register", "1"), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/* The fix lives in one macro shared by every boolean directive, so a directive
+ * other than register must behave identically. */
+START_TEST(test_notifications_enabled_trailing_char_rejected)
+{
+	ck_assert_int_eq(parse_host_with("notifications_enabled", "0v"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_contact_notification_bools_accepted)
+{
+	object_def_start("timeperiod");
+	object_def_var("timeperiod_name", "none");
+	object_def_var("alias", "Nothing");
+	object_def_end();
+
+	object_def_start("contact");
+	object_def_var("contact_name", "test_contact");
+	object_def_var("host_notifications_enabled", "0");
+	object_def_var("service_notifications_enabled", "1");
+	object_def_var("host_notification_period", "none");
+	object_def_var("service_notification_period", "none");
+	object_def_end();
+
+	ck_assert_int_eq(read_all_object_data_capture(), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/* The Nagios documentation defines these directives as 0/1 only - word forms
+ * are not an accepted spelling. */
+START_TEST(test_register_true_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "true"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_yes_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "yes"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_register_on_rejected)
+{
+	ck_assert_int_eq(parse_host_with("register", "on"), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/* Unchanged behaviour, pinned so it stays that way. */
+START_TEST(test_register_without_value_rejected)
+{
+	object_def_start("host");
+	object_def_var("host_name", "test_host");
+	object_def_var("address", "127.0.0.1");
+	object_def_var("max_check_attempts", "1");
+	object_def_raw("    register");
+	object_def_end();
+
+	ck_assert_int_eq(read_all_object_data_capture(), ERROR);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/******************************************************************************
+ * Whitespace around the value is not part of the value.
+ *
+ * Matching the value in full is only safe because the caller has already run
+ * it through trim(). These tests fail loudly if that ever stops being true.
+ *****************************************************************************/
+
+START_TEST(test_value_tab_separated_accepted)
+{
+	object_def_start("host");
+	object_def_var("host_name", "test_host");
+	object_def_var("address", "127.0.0.1");
+	object_def_var("max_check_attempts", "1");
+	object_def_raw("\tregister\t0");
+	object_def_end();
+
+	ck_assert_int_eq(read_all_object_data_capture(), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_value_trailing_whitespace_accepted)
+{
+	object_def_start("host");
+	object_def_var("host_name", "test_host");
+	object_def_var("address", "127.0.0.1");
+	object_def_var("max_check_attempts", "1");
+	object_def_raw("    register     0   \t  ");
+	object_def_end();
+
+	ck_assert_int_eq(read_all_object_data_capture(), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_value_trailing_comment_accepted)
+{
+	object_def_start("host");
+	object_def_var("host_name", "test_host");
+	object_def_var("address", "127.0.0.1");
+	object_def_var("max_check_attempts", "1");
+	object_def_raw("    register 0 ; registered as a template");
+	object_def_end();
+
+	ck_assert_int_eq(read_all_object_data_capture(), OK);
+	unlink(cur_config_file);
+}
+END_TEST
+
+/******************************************************************************
+ * The error names the directive exactly as written in the config file.
+ *
+ * Several directives do not share a name with the struct member they set, so
+ * reporting the member would name something the user never wrote:
+ *   register            -> register_object
+ *   checks_enabled      -> active_checks_enabled
+ *   obsess_over_host    -> obsess
+ *****************************************************************************/
+
+START_TEST(test_error_names_register_not_member)
+{
+	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_output_contains("'register'");
+	ck_assert_output_lacks("register_object");
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_error_quotes_rejected_value)
+{
+	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_output_contains("'0v'");
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_error_names_alias_as_written)
+{
+	ck_assert_int_eq(parse_host_with("checks_enabled", "0v"), ERROR);
+	ck_assert_output_contains("'checks_enabled'");
+	ck_assert_output_lacks("active_checks_enabled");
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_error_names_canonical_alias_as_written)
+{
+	ck_assert_int_eq(parse_host_with("active_checks_enabled", "0v"), ERROR);
+	ck_assert_output_contains("'active_checks_enabled'");
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_error_names_obsess_over_host_as_written)
+{
+	ck_assert_int_eq(parse_host_with("obsess_over_host", "0v"), ERROR);
+	ck_assert_output_contains("'obsess_over_host'");
+	ck_assert_output_lacks("'obsess'");
+	unlink(cur_config_file);
+}
+END_TEST
+
+START_TEST(test_error_names_obsess_as_written)
+{
+	ck_assert_int_eq(parse_host_with("obsess", "0v"), ERROR);
+	ck_assert_output_contains("'obsess'");
+	unlink(cur_config_file);
+}
+END_TEST
+
+/* The file and line come from the caller and must still accompany the value
+ * error, so an operator can find the offending directive. */
+START_TEST(test_error_reports_file_and_line)
+{
+	ck_assert_int_eq(parse_host_with("register", "0v"), ERROR);
+	ck_assert_output_contains("Could not add object property in file");
+	ck_assert_output_contains(cur_config_file);
+	unlink(cur_config_file);
+}
+END_TEST
+
 Suite *obj_config_parse_suite(void)
 {
 	Suite *s = suite_create("Object config parse");
@@ -166,6 +491,32 @@ Suite *obj_config_parse_suite(void)
 	tcase_add_checked_fixture(parse, init_configuration, free_configuration);
 
 	tcase_add_test(parse, test_hostgroup_service_host_override);
+
+	tcase_add_test(parse, test_register_trailing_char_rejected);
+	tcase_add_test(parse, test_register_ten_rejected);
+	tcase_add_test(parse, test_register_one_trailing_char_rejected);
+	tcase_add_test(parse, test_register_leading_char_rejected);
+	tcase_add_test(parse, test_register_double_zero_rejected);
+	tcase_add_test(parse, test_register_zero_accepted);
+	tcase_add_test(parse, test_register_one_accepted);
+	tcase_add_test(parse, test_notifications_enabled_trailing_char_rejected);
+	tcase_add_test(parse, test_contact_notification_bools_accepted);
+	tcase_add_test(parse, test_register_true_rejected);
+	tcase_add_test(parse, test_register_yes_rejected);
+	tcase_add_test(parse, test_register_on_rejected);
+	tcase_add_test(parse, test_register_without_value_rejected);
+
+	tcase_add_test(parse, test_value_tab_separated_accepted);
+	tcase_add_test(parse, test_value_trailing_whitespace_accepted);
+	tcase_add_test(parse, test_value_trailing_comment_accepted);
+
+	tcase_add_test(parse, test_error_names_register_not_member);
+	tcase_add_test(parse, test_error_quotes_rejected_value);
+	tcase_add_test(parse, test_error_names_alias_as_written);
+	tcase_add_test(parse, test_error_names_canonical_alias_as_written);
+	tcase_add_test(parse, test_error_names_obsess_over_host_as_written);
+	tcase_add_test(parse, test_error_names_obsess_as_written);
+	tcase_add_test(parse, test_error_reports_file_and_line);
 
 	suite_add_tcase(s, parse);
 	return s;


### PR DESCRIPTION
xod_parse_bool() examined only the first character of a directive's value, so everything after it was silently discarded. "register 0v" and "register 0nono" were read as 0, and "register 10" as 1.

The 0-prefixed case is the damaging one. The object is treated as an unregistered template, so a single stray character removes a host from monitoring while naemon starts up cleanly and reports nothing at all.

The value is now compared in full and only "0" and "1" are accepted, as the documentation has always specified. Anything else is a config error, so the object config is rejected, the pre-flight check does not run and naemon does not start.

The error also names the directive as written in the config file and quotes the offending value:

    Error: invalid value '0v' for 'register', expected 0 or 1.

It previously printed the struct member name, which for "register" is "register_object" - a directive that appears in no config file. The name now comes from the parsed token rather than the member, so aliases are reported as written too: "checks_enabled" is not reported as "active_checks_enabled", nor "obsess_over_host" as "obsess".

This is a breaking change. Configurations accepted before will now be rejected, so run naemon -v before upgrading and before reloading a running instance.

Affected directives:
- register
- active_checks_enabled (alias checks_enabled)
- passive_checks_enabled
- event_handler_enabled
- flap_detection_enabled
- check_freshness
- process_perf_data
- obsess (aliases obsess_over_host, obsess_over_service)
- is_volatile
- notifications_enabled
- host_notifications_enabled, service_notifications_enabled
- retain_status_information, retain_nonstatus_information
- inherits_parent
- can_submit_commands