### PR TITLE
Fix wrong values for timeout in host and service check results

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,8 @@ AX_CHECK_COMPILE_FLAG([-Wall], AM_CFLAGS+=" -Wall")
 AX_CHECK_COMPILE_FLAG([-Werror], AM_CFLAGS+=" -Werror")
 AX_CHECK_COMPILE_FLAG([-fPIC], AM_CFLAGS+=" -fPIC")
 AX_CHECK_COMPILE_FLAG([-Wextra], AM_CFLAGS+=" -Wextra")
+# We really want to enable -Wsign-conversion but this throws a log of warnings at the moment
+#AX_CHECK_COMPILE_FLAG([-Wsign-conversion], AM_CFLAGS+=" -Wsign-conversion")
 AX_CHECK_COMPILE_FLAG([-pipe], AM_CFLAGS+=" -pipe")
 AX_CHECK_COMPILE_FLAG([-ggdb3], AM_CFLAGS+=" -ggdb3")
 AX_CHECK_COMPILE_FLAG([-Wredundant-decls], AM_CFLAGS+=" -Wredundant-decls")

--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -525,6 +525,7 @@ int init_check_result(check_result *info)
 	info->start_time.tv_usec = 0;
 	info->finish_time.tv_sec = 0;
 	info->finish_time.tv_usec = 0;
+	info->timeout = 0;
 	info->early_timeout = FALSE;
 	info->exited_ok = TRUE;
 	info->return_code = 0;

--- a/src/naemon/checks.c
+++ b/src/naemon/checks.c
@@ -462,6 +462,8 @@ int process_check_result_file(char *fname)
 				cr.early_timeout = atoi(val);
 			else if (!strcmp(var, "exited_ok"))
 				cr.exited_ok = atoi(val);
+			else if (!strcmp(var, "timeout"))
+				cr.timeout = atoi(val);
 			else if (!strcmp(var, "return_code"))
 				cr.return_code = atoi(val);
 			else if (!strcmp(var, "output"))

--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -565,6 +565,7 @@ int update_host_state_post_check(struct host *hst, struct check_result *cr)
 int handle_async_host_check_result(host *temp_host, check_result *cr)
 {
 	int alert_recorded = NEBATTR_NONE;
+	int effective_timeout;
 	struct host pre;
 	int first_recorded_state = NEBATTR_NONE;
 
@@ -611,6 +612,9 @@ int handle_async_host_check_result(host *temp_host, check_result *cr)
 
 	log_debug_info(DEBUGL_CHECKS, 1, "** Async check result for host '%s' handled: new state=%d\n", temp_host->name, temp_host->current_state);
 
+	/* Keep timeout meaningful in broker callbacks for passive/legacy records. */
+	effective_timeout = cr->timeout > 0 ? cr->timeout : temp_host->check_timeout;
+
 	broker_host_check(
 	    NEBTYPE_HOSTCHECK_PROCESSED,
 	    NEBFLAG_NONE,
@@ -624,7 +628,7 @@ int handle_async_host_check_result(host *temp_host, check_result *cr)
 	    temp_host->check_command,
 	    temp_host->latency,
 	    temp_host->execution_time,
-	    cr->timeout,
+	    effective_timeout,
 	    cr->early_timeout,
 	    cr->return_code,
 	    NULL,

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -483,6 +483,7 @@ static void handle_worker_service_check(wproc_result *wpres, void *arg, int flag
 int handle_async_service_check_result(service *temp_service, check_result *queued_check_result)
 {
 	host *temp_host = NULL;
+	int effective_timeout;
 	int state_change = FALSE;
 	int hard_state_change = FALSE;
 	int first_host_check_initiated = FALSE;
@@ -1115,6 +1116,12 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 		}
 	}
 
+	/*
+	 * Legacy/passive result sources may not carry timeout in the check_result
+	 * payload. Keep broker callbacks consistent by falling back to object config.
+	 */
+	effective_timeout = queued_check_result->timeout > 0 ? queued_check_result->timeout : temp_service->check_timeout;
+
 	broker_service_check(
 	    NEBTYPE_SERVICECHECK_PROCESSED,
 	    NEBFLAG_NONE,
@@ -1126,7 +1133,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	    temp_service->check_command,
 	    temp_service->latency,
 	    temp_service->execution_time,
-	    queued_check_result->timeout,
+	    effective_timeout,
 	    queued_check_result->early_timeout,
 	    queued_check_result->return_code,
 	    NULL,


### PR DESCRIPTION
This fixes two bugs:

1. The value of `timeout` was not initialized in the check_result data, therefore the value was what ever is in memory.
2. Fallback to the default timeout, when no object specific timeout was given

New feature:
The spoolfiles can now also pass a field `timeout`. 

The screenshot shows the issue. The high/negativ value are caused because of `timeout` was not initialized.
The `0` values are because there was no fallback to the default.

Above the blue selection, everything is as expected.


<img width="1547" height="785" alt="Bildschirmfoto 2026-09-01 um 17 43 09" src="https://github.com/user-attachments/assets/ed52752c-c232-4936-9881-307c53279da5" />

Resolve #539