### PR TITLE
fix multiple libasan findings

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   citest:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@main
       #- name: Setup tmate session, see https://github.com/marketplace/actions/debugging-with-tmate
@@ -18,6 +18,7 @@ jobs:
           sudo apt-get install \
               autoconf \
               build-essential \
+              libasan8 \
               libglib2.0-dev \
               gperf \
               check \
@@ -28,7 +29,7 @@ jobs:
 
       - name: run build
         run: |
-          ./autogen.sh
+          CFLAGS='-g -O0 -fsanitize=address -fno-omit-frame-pointer' ./autogen.sh
           make
 
       - name: run tests

--- a/lib/test-bitmap.c
+++ b/lib/test-bitmap.c
@@ -87,6 +87,13 @@ int main(int argc, char **argv)
 	ok_int(bitmap_count_unset_bits(a), bitmap_cardinality(a), "bitmap_clear() must clear all");
 	ok_int(bitmap_count_set_bits(a), 0, "bitmap_clear() must clear all (part 2)");
 
+	bitmap_destroy(r_union);
+	bitmap_destroy(r_diff);
+	bitmap_destroy(r_symdiff);
+	bitmap_destroy(r_intersect);
+	bitmap_destroy(a);
+	bitmap_destroy(b);
+
 	t_end();
 	return 0;
 }

--- a/lib/test-nsutils.c
+++ b/lib/test-nsutils.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "nsutils.c"
 #include "t-utils.h"
 #include <sys/time.h>
@@ -34,6 +35,7 @@ int main(int argc, char **argv)
 	}
 	s2 = mkstr("arg varg foo %d", 12);
 	ok_str(s1, s2, "mkstr() must build proper strings");
+	free(s1);
 	if (real_online_cpus() > 0) {
 		t_pass("%d online cpus detected", real_online_cpus());
 	} else {

--- a/lib/test-runcmd.c
+++ b/lib/test-runcmd.c
@@ -115,13 +115,17 @@ int main(int argc, char **argv)
 			fd = runcmd_open(cmd, pfd, pfderr);
 			if (read(pfd[0], out, BUF_SIZE) < 0) {
 				t_fail("read returned failure: %s", strerror(errno));
+				close(fd);
+				free(cmd);
 				continue;
 			}
 			ok_str(cases[i].output, out, "Echoing a command should give expected output");
 			close(pfd[0]);
 			close(pfderr[0]);
 			close(fd);
+			free(cmd);
 		}
+		free(out);
 	}
 	ret = t_end();
 	t_reset();
@@ -134,6 +138,8 @@ int main(int argc, char **argv)
 			char *out_env[256];
 			int result = runcmd_cmd2strv(anomaly[i].cmd, &out_argc, out_argv, &out_envc, out_env);
 			ok_int(result, anomaly[i].ret, anomaly[i].cmd);
+			free(out_argv[0]);
+			free(out_env[0]);
 		}
 	}
 	r2 = t_end();
@@ -157,6 +163,8 @@ int main(int argc, char **argv)
 			for (x = 0; x < parse_case[x].envc_exp; x++) {
 				ok_str(parse_case[i].env_exp[x], out_env[x], "env comparison test");
 			}
+			free(out_argv[0]);
+			free(out_env[0]);
 		}
 	}
 

--- a/src/naemon/checks_host.c
+++ b/src/naemon/checks_host.c
@@ -359,6 +359,8 @@ static int run_async_host_check(host *hst, int check_options, double latency)
 	if (runchk_result == ERROR) {
 		nm_log(NSLOG_RUNTIME_ERROR,
 		       "Unable to send check for host '%s' to worker (ret=%d)\n", hst->name, runchk_result);
+		free_check_result(cr);
+		nm_free(cr);
 	} else {
 		/* do the book-keeping */
 		currently_running_host_checks++;

--- a/src/naemon/checks_service.c
+++ b/src/naemon/checks_service.c
@@ -426,6 +426,8 @@ static int run_scheduled_service_check(service *svc, int check_options, double l
 	if (runchk_result == ERROR) {
 		nm_log(NSLOG_RUNTIME_ERROR,
 		       "Unable to send check for service '%s' on host '%s' to worker (ret=%d)\n", svc->description, svc->host_name, runchk_result);
+		free_check_result(cr);
+		nm_free(cr);
 	} else {
 		/* do the book-keeping */
 		currently_running_service_checks++;

--- a/src/naemon/configuration.c
+++ b/src/naemon/configuration.c
@@ -1132,6 +1132,11 @@ read_config_file(const char *main_config_file, nagios_macros *mac)
 	/* handle errors */
 	if (error == TRUE) {
 		nm_log(NSLOG_CONFIG_ERROR, "Error in configuration file '%s' - Line %d (%s)", main_config_file, current_line, (error_message == NULL) ? "NULL" : error_message);
+		mmap_fclose(thefile);
+		nm_free(input);
+		nm_free(variable);
+		nm_free(value);
+		nm_free(error_message);
 		return ERROR;
 	}
 

--- a/src/naemon/events.c
+++ b/src/naemon/events.c
@@ -23,8 +23,7 @@ struct timed_event_queue {
 	size_t size;
 };
 
-struct timed_event_queue *event_queue = NULL; /* our scheduling queue */
-iobroker_set *nagios_iobs = NULL;
+static struct timed_event_queue *event_queue = NULL; /* our scheduling queue */
 
 /******************************************************************/
 /************************** TIME HELPERS *************************/

--- a/src/naemon/logging.c
+++ b/src/naemon/logging.c
@@ -95,7 +95,7 @@ static int write_to_syslog(char *buffer, unsigned long data_type)
 }
 
 /* write something to the naemon log file */
-static int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp)
+int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp)
 {
 	FILE *fp;
 	time_t log_time = 0L;

--- a/src/naemon/logging.h
+++ b/src/naemon/logging.h
@@ -87,6 +87,7 @@ int log_debug_info(int, int, const char *, ...)
 __attribute__((__format__(__printf__, 3, 4)));
 
 int rotate_log_file(time_t);            /* rotates the main log file */
+int write_to_log(char *, unsigned long, time_t *); /* writes a line to the main log file */
 int write_log_file_info(time_t *);      /* records log file/version info */
 int open_debug_log(void);
 int close_debug_log(void);

--- a/src/naemon/macros.c
+++ b/src/naemon/macros.c
@@ -893,11 +893,11 @@ static int grab_standard_host_macro_r(nagios_macros *mac, int macro_type, host *
 
 
 /* computes a hostgroup macro */
-static int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, hostgroup *temp_hostgroup, char **output)
+static int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, hostgroup *temp_hostgroup, char **output, int *free_macro)
 {
 	char *temp_buffer = NULL;
 
-	if (temp_hostgroup == NULL || output == NULL)
+	if (temp_hostgroup == NULL || output == NULL || free_macro == NULL)
 		return ERROR;
 
 	/* get the macro value */
@@ -936,10 +936,12 @@ static int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, h
 	switch (macro_type) {
 	case MACRO_HOSTGROUPACTIONURL:
 	case MACRO_HOSTGROUPNOTESURL:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
 		*output = temp_buffer;
 		break;
 	case MACRO_HOSTGROUPNOTES:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, 0);
 		*output = temp_buffer;
 		break;
@@ -1147,10 +1149,12 @@ static int grab_standard_service_macro_r(nagios_macros *mac, int macro_type, ser
 	switch (macro_type) {
 	case MACRO_SERVICEACTIONURL:
 	case MACRO_SERVICENOTESURL:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
 		*output = temp_buffer;
 		break;
 	case MACRO_SERVICENOTES:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, 0);
 		*output = temp_buffer;
 		break;
@@ -1163,14 +1167,14 @@ static int grab_standard_service_macro_r(nagios_macros *mac, int macro_type, ser
 
 
 /* computes a servicegroup macro */
-static int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type, servicegroup *temp_servicegroup, char **output)
+static int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type, servicegroup *temp_servicegroup, char **output, int *free_macro)
 {
 	servicesmember *temp_servicesmember = NULL;
 	char *temp_buffer = NULL;
 	unsigned int temp_len = 0;
 	unsigned int init_len = 0;
 
-	if (temp_servicegroup == NULL || output == NULL)
+	if (temp_servicegroup == NULL || output == NULL || free_macro == NULL)
 		return ERROR;
 
 	/* get the macro value */
@@ -1240,10 +1244,12 @@ static int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type
 	switch (macro_type) {
 	case MACRO_SERVICEGROUPACTIONURL:
 	case MACRO_SERVICEGROUPNOTESURL:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
 		*output = temp_buffer;
 		break;
 	case MACRO_SERVICEGROUPNOTES:
+		*free_macro = TRUE;
 		process_macros_r(mac, *output, &temp_buffer, 0);
 		*output = temp_buffer;
 		break;
@@ -1625,6 +1631,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 
 			g_tree_foreach(temp_hostgroup->members, concat_macrox_value, &params);
 			*output = nm_malloc(params.buffer->len + 1);
+			*free_macro = TRUE;
 			strncpy(*output, params.buffer->str, params.buffer->len);
 			(*output)[params.buffer->len] = 0;
 			g_string_free(params.buffer, TRUE);
@@ -1657,7 +1664,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		}
 
 		/* get the hostgroup macro value */
-		result = grab_standard_hostgroup_macro_r(mac, macro_type, temp_hostgroup, output);
+		result = grab_standard_hostgroup_macro_r(mac, macro_type, temp_hostgroup, output, free_macro);
 		break;
 
 	/******************/
@@ -1804,7 +1811,7 @@ static int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, c
 		}
 
 		/* get the servicegroup macro value */
-		result = grab_standard_servicegroup_macro_r(mac, macro_type, temp_servicegroup, output);
+		result = grab_standard_servicegroup_macro_r(mac, macro_type, temp_servicegroup, output, free_macro);
 		break;
 
 	/******************/

--- a/src/naemon/nebmods.c
+++ b/src/naemon/nebmods.c
@@ -583,9 +583,9 @@ int neb_deregister_callback(enum NEBCallbackType callback_type, void *callback_f
 		return NEBERROR_CALLBACKNOTFOUND;
 
 	else {
-		/* only one item in the list */
+		/* unlink the callback from the list */
 		if (temp_callback != last_callback->next)
-			neb_callback_list[callback_type] = NULL;
+			neb_callback_list[callback_type] = next_callback;
 		else
 			last_callback->next = next_callback;
 		nm_free(temp_callback);
@@ -722,6 +722,7 @@ int neb_free_callback_list(void)
 	}
 
 	nm_free(neb_callback_list);
+	neb_callback_list = NULL;
 
 	return OK;
 }

--- a/src/naemon/objects_contact.c
+++ b/src/naemon/objects_contact.c
@@ -164,6 +164,8 @@ void destroy_contact(contact *this_contact)
 	nm_free(this_contact->pager);
 	for (j = 0; j < MAX_CONTACT_ADDRESSES; j++)
 		nm_free(this_contact->address[j]);
+	nm_free(this_contact->host_notification_period);
+	nm_free(this_contact->service_notification_period);
 
 	free_objectlist(&this_contact->contactgroups_ptr);
 	nm_free(this_contact);

--- a/src/naemon/objects_timeperiod.c
+++ b/src/naemon/objects_timeperiod.c
@@ -411,7 +411,7 @@ static int get_dst_shift(time_t *start, time_t *end)
 
 
 /*#define TEST_TIMEPERIODS_A 1*/
-static timerange *_get_matching_timerange(time_t test_time, const timeperiod *tperiod)
+timerange *_get_matching_timerange(time_t test_time, const timeperiod *tperiod)
 {
 	daterange *temp_daterange = NULL;
 	time_t start_time = (time_t)0L;
@@ -677,9 +677,6 @@ int check_time_against_period(time_t test_time, const timeperiod *tperiod)
 }
 
 
-/*#define TEST_TIMEPERIODS_B 1*/
-static void _get_next_valid_time(time_t pref_time, time_t *valid_time, const timeperiod *tperiod);
-
 /* calculate the next time this period ends */
 void get_next_invalid_time(time_t pref_time, time_t *invalid_time, const timeperiod *tperiod)
 {
@@ -796,7 +793,7 @@ void get_next_invalid_time(time_t pref_time, time_t *invalid_time, const timeper
 
 
 /* Separate this out from public get_next_valid_time for testing */
-static void _get_next_valid_time(time_t pref_time, time_t *valid_time, const timeperiod *tperiod)
+void _get_next_valid_time(time_t pref_time, time_t *valid_time, const timeperiod *tperiod)
 {
 	timeperiodexclusion *temp_timeperiodexclusion = NULL;
 	int depth = 0;

--- a/src/naemon/objects_timeperiod.h
+++ b/src/naemon/objects_timeperiod.h
@@ -91,5 +91,8 @@ int check_time_against_period(time_t, const timeperiod *);	/* check to see if a 
 void get_next_valid_time(time_t, time_t *, const timeperiod *);	/* get the next valid time in a time period */
 void get_next_invalid_time(time_t, time_t *, const timeperiod *);	/* get the next invalid time in a time period (aka end of the period) */
 
+timerange *_get_matching_timerange(time_t, const timeperiod *);	/* internal, exported for testing */
+void _get_next_valid_time(time_t, time_t *, const timeperiod *);	/* internal, exported for testing */
+
 NAGIOS_END_DECL
 #endif

--- a/src/naemon/query-handler.c
+++ b/src/naemon/query-handler.c
@@ -26,7 +26,7 @@ struct query_handler {
 static struct query_handler *qhandlers;
 static int qh_listen_sock = -1; /* the listening socket */
 static unsigned int qh_running;
-unsigned int qh_max_running = 0; /* defaults to unlimited */
+static unsigned int qh_max_running = 0; /* defaults to unlimited */
 static GHashTable *qh_table;
 
 /* the echo service. stupid, but useful for testing */

--- a/src/naemon/utils.c
+++ b/src/naemon/utils.c
@@ -47,6 +47,8 @@ objectlist *objcfg_files = NULL;
 objectlist *objcfg_dirs = NULL;
 int upipe_fd[2];
 
+iobroker_set *nagios_iobs = NULL;
+
 int num_check_workers = 0; /* auto-decide */
 char *qh_socket_path = NULL; /* disabled */
 

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -2565,6 +2565,9 @@ static int xodtemplate_duplicate_hostescalation(xodtemplate_hostescalation *temp
 
 	new_hostescalation->host_name = host_name;
 
+	if (temp_hostescalation->escalation_period != NULL)
+		new_hostescalation->escalation_period = nm_strdup(temp_hostescalation->escalation_period);
+
 	if (temp_hostescalation->contact_groups != NULL)
 		new_hostescalation->contact_groups = nm_strdup(temp_hostescalation->contact_groups);
 
@@ -2591,6 +2594,9 @@ static int xodtemplate_duplicate_serviceescalation(xodtemplate_serviceescalation
 	new_serviceescalation->is_copy = TRUE;
 	new_serviceescalation->host_name = host_name;
 	new_serviceescalation->service_description = svc_description;
+
+	if (temp_serviceescalation->escalation_period != NULL)
+		new_serviceescalation->escalation_period = nm_strdup(temp_serviceescalation->escalation_period);
 
 	if (temp_serviceescalation->contact_groups != NULL)
 		new_serviceescalation->contact_groups = nm_strdup(temp_serviceescalation->contact_groups);
@@ -6016,9 +6022,7 @@ static int xodtemplate_register_and_destroy_hostescalation(void *he_)
 	int result;
 
 	result = xodtemplate_register_hostescalation(he);
-	if (he->is_copy == FALSE) {
-		nm_free(he->escalation_period);
-	}
+	nm_free(he->escalation_period);
 	nm_free(he->contact_groups);
 	nm_free(he->contacts);
 	nm_free(he);
@@ -6487,9 +6491,7 @@ static int xodtemplate_register_and_destroy_serviceescalation(void *se_)
 	int result;
 	result = xodtemplate_register_serviceescalation(se);
 
-	if (se->is_copy == FALSE)
-		nm_free(se->escalation_period);
-
+	nm_free(se->escalation_period);
 	nm_free(se->contact_groups);
 	nm_free(se->contacts);
 	nm_free(se);

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -2436,7 +2436,6 @@ static int xodtemplate_duplicate_services(void)
 			}
 			/* we don't need this anymore now that we have the hlist */
 			nm_free(temp_service->host_name);
-			temp_service->host_name = NULL;
 		}
 
 		/*

--- a/src/naemon/xodtemplate.c
+++ b/src/naemon/xodtemplate.c
@@ -435,6 +435,7 @@ static void xodtemplate_free_memory(void)
 		nm_free(this_service->contact_groups);
 		nm_free(this_service->contacts);
 		nm_free(this_service->service_groups);
+		nm_free(this_service->host_name);
 
 		if (this_service->is_copy == FALSE) {
 			/* free custom variables */
@@ -2352,7 +2353,7 @@ static int xodtemplate_duplicate_service(xodtemplate_service *temp_service, char
 	memcpy(new_service, temp_service, sizeof(*new_service));
 	new_service->is_copy = TRUE;
 	new_service->id = xodcount.services++;
-	new_service->host_name = host_name;
+	new_service->host_name = nm_strdup(host_name);
 
 	/* tag service apply on host group */
 	new_service->is_from_hostgroup = from_hg;
@@ -2435,6 +2436,7 @@ static int xodtemplate_duplicate_services(void)
 			}
 			/* we don't need this anymore now that we have the hlist */
 			nm_free(temp_service->host_name);
+			temp_service->host_name = NULL;
 		}
 
 		/*
@@ -2474,7 +2476,7 @@ static int xodtemplate_duplicate_services(void)
 				/* if this is the last duplication, use the existing entry */
 				if (!next && !hlist->next) {
 					temp_service->id = xodcount.services++;
-					temp_service->host_name = h->host_name;
+					temp_service->host_name = nm_strdup(h->host_name);
 					temp_service->is_from_hostgroup = (hg != &fake_hg);
 				} else {
 					/* duplicate service definition */

--- a/src/naemonstats/naemonstats.c
+++ b/src/naemonstats/naemonstats.c
@@ -20,7 +20,6 @@
 
 
 static char *main_config_file = NULL;
-char *status_file = NULL;
 static char *mrtg_variables = NULL;
 static const char *mrtg_delimiter = "\n";
 char *mrtg_delimiter_save = NULL;
@@ -29,10 +28,8 @@ static int mrtg_mode = FALSE;
 
 static time_t status_creation_date = 0L;
 static char *status_version = NULL;
-time_t program_start = 0L;
 static int status_service_entries = 0;
 static int status_host_entries = 0;
-int nagios_pid = 0;
 
 static double min_service_state_change = 0.0;
 static int have_min_service_state_change = FALSE;

--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -22,9 +22,25 @@ int found_log_rechecking_host_when_service_wobbles = 0;
 int found_log_run_async_host_check = 0;
 check_result *tmp_check_result;
 
+static void set_check_result_output(const char *output)
+{
+	free(tmp_check_result->output);
+	tmp_check_result->output = strdup(output);
+}
+
+void destroy_check_result(void)
+{
+	if (tmp_check_result == NULL)
+		return;
+	free_check_result(tmp_check_result);
+	free(tmp_check_result);
+	tmp_check_result = NULL;
+}
+
 void setup_check_result(void)
 {
 	struct timeval start_time, finish_time;
+	destroy_check_result();
 	start_time.tv_sec = 1234567890L;
 	start_time.tv_usec = 0L;
 	finish_time.tv_sec = 1234567891L;
@@ -126,7 +142,7 @@ int main(int argc, char **argv)
 	tmp_check_result->early_timeout = 0;
 	tmp_check_result->exited_ok = TRUE;
 	tmp_check_result->return_code = 1;
-	tmp_check_result->output = strdup("Warning - check notified_on OPT_CRITICAL flag reset");
+	set_check_result_output("Warning - check notified_on OPT_CRITICAL flag reset");
 
 	setup_objects(now);
 	svc1->last_state = STATE_CRITICAL;
@@ -197,7 +213,7 @@ int main(int argc, char **argv)
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure");
+	set_check_result_output("WARNING failure");
 	handle_async_service_check_result(svc1, tmp_check_result);
 
 	ok(svc1->last_notification == (time_t)0, "last notification reset due to state change");
@@ -210,14 +226,14 @@ int main(int argc, char **argv)
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure");
+	set_check_result_output("WARNING failure");
 	handle_async_service_check_result(svc1, tmp_check_result);
 
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack left");
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_OK;
-	tmp_check_result->output = strdup("Back to OK");
+	set_check_result_output("Back to OK");
 	handle_async_service_check_result(svc1, tmp_check_result);
 
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NONE, "Ack reset to none");
@@ -241,12 +257,12 @@ int main(int argc, char **argv)
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_OK;
-	tmp_check_result->output = strdup("Reset to OK");
+	set_check_result_output("Reset to OK");
 	handle_async_service_check_result(svc1, tmp_check_result);
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 1");
+	set_check_result_output("WARNING failure 1");
 	handle_async_service_check_result(svc1, tmp_check_result);
 
 	ok(svc1->state_type == SOFT_STATE, "Soft state");
@@ -256,28 +272,28 @@ int main(int argc, char **argv)
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 2");
+	set_check_result_output("WARNING failure 2");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->state_type == SOFT_STATE, "Soft state");
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack left");
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 3");
+	set_check_result_output("WARNING failure 3");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->state_type == SOFT_STATE, "Soft state");
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack left");
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 4");
+	set_check_result_output("WARNING failure 4");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->state_type == HARD_STATE, "Hard state");
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack left on hard failure");
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_OK;
-	tmp_check_result->output = strdup("Back to OK");
+	set_check_result_output("Back to OK");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NONE, "Ack removed");
 	destroy_objects();
@@ -300,7 +316,7 @@ int main(int argc, char **argv)
 	svc1->max_attempts = 2;
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 1");
+	set_check_result_output("WARNING failure 1");
 
 	handle_async_service_check_result(svc1, tmp_check_result);
 
@@ -310,13 +326,13 @@ int main(int argc, char **argv)
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_WARNING;
-	tmp_check_result->output = strdup("WARNING failure 2");
+	set_check_result_output("WARNING failure 2");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack left");
 
 	setup_check_result();
 	tmp_check_result->return_code = STATE_OK;
-	tmp_check_result->output = strdup("Back to OK");
+	set_check_result_output("Back to OK");
 	handle_async_service_check_result(svc1, tmp_check_result);
 	ok(svc1->acknowledgement_type == ACKNOWLEDGEMENT_NONE, "Ack removed");
 	destroy_objects();
@@ -337,13 +353,14 @@ int main(int argc, char **argv)
 	host1->plugin_output = strdup("");
 	host1->long_plugin_output = strdup("");
 	host1->perf_data = strdup("");
+	free(host1->check_command);
 	host1->check_command = strdup("Dummy command required");
 	host1->accept_passive_checks = TRUE;
 	passive_host_checks_are_soft = TRUE;
 	setup_check_result();
 
 	tmp_check_result->return_code = STATE_CRITICAL;
-	tmp_check_result->output = strdup("DOWN failure 2");
+	set_check_result_output("DOWN failure 2");
 	tmp_check_result->check_type = HOST_CHECK_PASSIVE;
 	handle_async_host_check_result(host1, tmp_check_result);
 	ok(host1->acknowledgement_type == ACKNOWLEDGEMENT_NONE, "No ack set");
@@ -354,6 +371,7 @@ int main(int argc, char **argv)
 
 	host1->acknowledgement_type = ACKNOWLEDGEMENT_NORMAL;
 
+	free(tmp_check_result->output);
 	tmp_check_result->output = strdup("DOWN failure 3");
 	handle_async_host_check_result(host1, tmp_check_result);
 	ok(host1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack should be retained as in soft state");
@@ -363,6 +381,7 @@ int main(int argc, char **argv)
 		diag("plugin_output=%s", host1->plugin_output);
 
 
+	free(tmp_check_result->output);
 	tmp_check_result->output = strdup("DOWN failure 4");
 	handle_async_host_check_result(host1, tmp_check_result);
 	ok(host1->acknowledgement_type == ACKNOWLEDGEMENT_NORMAL, "Ack should be retained as in soft state");
@@ -373,7 +392,7 @@ int main(int argc, char **argv)
 
 
 	tmp_check_result->return_code = STATE_OK;
-	tmp_check_result->output = strdup("UP again");
+	set_check_result_output("UP again");
 	handle_async_host_check_result(host1, tmp_check_result);
 	ok(host1->acknowledgement_type == ACKNOWLEDGEMENT_NONE, "Ack reset due to state change");
 	if (!ok(host1->current_attempt == 1, "Attempts reset"))
@@ -381,7 +400,7 @@ int main(int argc, char **argv)
 	if (!ok(strcmp(host1->plugin_output, "UP again") == 0, "output set"))
 		diag("plugin_output=%s", host1->plugin_output);
 	destroy_objects();
-
+	destroy_check_result();
 	destroy_event_queue();
 
 	return exit_status();

--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -14,7 +14,6 @@
 #include "naemon/perfdata.h"
 #include "tap.h"
 
-int date_format;
 
 /* Test specific functions + variables */
 service *svc1 = NULL, *svc2 = NULL;
@@ -45,6 +44,7 @@ void setup_check_result(void)
 
 void destroy_objects(void)
 {
+	clear_event_queue();
 	destroy_objects_host();
 	destroy_objects_service(TRUE);
 }

--- a/t-tap/test_macros.c
+++ b/t-tap/test_macros.c
@@ -117,6 +117,7 @@ nagios_macros *setup_macro_object(void)
 		} else { \
 			fail( "process_macros_r returns ERROR for " _STR ); \
 		} \
+		nm_free(output); \
 	} while(0)
 
 #define RUN_MACRO_TEST_EXPECT_SAME(_STR, _OPTS) \
@@ -228,7 +229,6 @@ int main(void)
 
 	reset_variables();
 	init_environment();
-	init_macros();
 
 	mac = setup_macro_object();
 

--- a/t-tap/test_timeperiods.c
+++ b/t-tap/test_timeperiods.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 #include <string.h>
 
-#include "naemon/objects_timeperiod.c"
+#include "naemon/objects_timeperiod.h"
 #include "naemon/utils.h"
 #include "naemon/configuration.h"
 #include "naemon/defaults.h"

--- a/tests/test-check-result-processing.c
+++ b/tests/test-check-result-processing.c
@@ -67,6 +67,9 @@ START_TEST(host_soft_to_hard)
 	ck_assert(cur.current_state == STATE_DOWN);
 	ck_assert(cur.has_been_checked == 1);
 	ck_assert(cur.state_type == HARD_STATE);
+	free(cur.plugin_output);
+	free(cur.long_plugin_output);
+	free(cur.perf_data);
 }
 END_TEST
 

--- a/tests/test-kvvec.c
+++ b/tests/test-kvvec.c
@@ -101,24 +101,22 @@ START_TEST(kvvec_tests)
 {
 	int i, j;
 	struct kvvec *kvv, *kvv2, *kvv3;
-	struct kvvec_buf *kvvb, *kvvb2;
-	struct kvvec k = KVVEC_INITIALIZER;
+	struct kvvec_buf *kvvb, *kvvb2, *kvvb1;
 
 	kvv = kvvec_create(1);
 	ck_assert_int_eq(kvvec_capacity(kvv), 1);
 	kvv2 = kvvec_create(1);
-	kvv3 = kvvec_create(1);
 	add_vars(kvv, test_data, 1239819);
 
 	kvvec_sort(kvv);
 	kvvec_foreach(kvv, NULL, walker);
 
 	/* kvvec2buf -> buf2kvvec -> kvvec2buf -> buf2kvvec conversion */
-	kvvb = kvvec2buf(kvv, KVSEP, PAIRSEP, OVERALLOC);
-	kvv3 = buf2kvvec(kvvb->buf, kvvb->buflen, KVSEP, PAIRSEP, KVVEC_COPY);
+	kvvb1 = kvvec2buf(kvv, KVSEP, PAIRSEP, OVERALLOC);
+	kvv3 = buf2kvvec(kvvb1->buf, kvvb1->buflen, KVSEP, PAIRSEP, KVVEC_COPY);
 	kvvb2 = kvvec2buf(kvv3, KVSEP, PAIRSEP, OVERALLOC);
 
-	buf2kvvec_prealloc(kvv2, kvvb->buf, kvvb->buflen, KVSEP, PAIRSEP, KVVEC_ASSIGN);
+	buf2kvvec_prealloc(kvv2, kvvb1->buf, kvvb1->buflen, KVSEP, PAIRSEP, KVVEC_ASSIGN);
 	kvvec_foreach(kvv2, kvv, walker);
 
 	kvvb = kvvec2buf(kvv, KVSEP, PAIRSEP, OVERALLOC);
@@ -147,23 +145,32 @@ START_TEST(kvvec_tests)
 	ck_assert(kvvb2->bufsize == kvvb->bufsize);
 	ck_assert(!memcmp(kvvb2->buf, kvvb->buf, kvvb->bufsize));
 
+	free(kvvb1->buf);
+	free(kvvb1);
 	free(kvvb->buf);
 	free(kvvb);
 	free(kvvb2->buf);
 	free(kvvb2);
-	kvvec_destroy(kvv, 1);
+	kvvec_destroy(kvv2, 0);
+	kvvec_destroy(kvv, KVVEC_FREE_ALL);
 	kvvec_destroy(kvv3, KVVEC_FREE_ALL);
 
 	for (j = 0; pair_term_missing[j]; j++) {
-		buf2kvvec_prealloc(&k, strdup(pair_term_missing[j]), strlen(pair_term_missing[j]), '=', ';', KVVEC_COPY);
-		for (i = 0; i < k.kv_pairs; i++) {
-			struct key_value *kv = &k.kv[i];
+		char *str = strdup(pair_term_missing[j]);
+		struct kvvec *k = kvvec_create(0);
+
+		buf2kvvec_prealloc(k, str, strlen(str), '=', ';', KVVEC_COPY);
+		free(str);
+
+		for (i = 0; i < k->kv_pairs; i++) {
+			struct key_value *kv = &k->kv[i];
 			ck_assert_msg(kv->key_len == kv->value_len, "%d.%d; key_len=%d; value_len=%d (%s = %s)",
 			              j, i, kv->key_len, kv->value_len, kv->key, kv->value);
 			ck_assert_msg(kv->value_len == (int)strlen(kv->value),
 			              "%d.%d; kv->value_len(%d) == strlen(%s)(%d)",
 			              j, i, kv->value_len, kv->value, (int)strlen(kv->value));
 		}
+		kvvec_destroy(k, KVVEC_FREE_ALL);
 	}
 
 }

--- a/tests/test-log.c
+++ b/tests/test-log.c
@@ -4,7 +4,8 @@
 #include <unistd.h>
 
 #include <check.h>
-#include "naemon/logging.c"
+#include "naemon/logging.h"
+#include "naemon/globals.h"
 
 
 START_TEST(common_case)
@@ -20,7 +21,7 @@ START_TEST(common_case)
 	workdir = getcwd(NULL, 0);
 	ret = asprintf(&rotated_file, "%s/old.log", workdir);
 	ret = asprintf(&log_file, "%s/active.log", workdir);
-	free(workdir);
+	nm_free(workdir);
 
 	// please fail if the files already exist:
 	ck_assert_msg(access(log_file, F_OK) == -1,
@@ -51,6 +52,8 @@ START_TEST(common_case)
 	ck_assert_str_eq("[5678] Log information\n", rotated_contents);
 	unlink(rotated_file);
 	unlink(log_file);
+	nm_free(rotated_file);
+	nm_free(log_file);
 }
 END_TEST
 

--- a/tests/test-retention.c
+++ b/tests/test-retention.c
@@ -75,7 +75,7 @@ void teardown(void)
 START_TEST(retention_data_for_hosts_long_output)
 {
 
-	const char *long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
+	char *long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
 
 	hst->long_plugin_output = strdup(long_output);
 
@@ -87,13 +87,15 @@ START_TEST(retention_data_for_hosts_long_output)
 	ck_assert(OK == read_initial_state_information());
 	ck_assert_str_eq(hst->long_plugin_output, long_output);
 
+	g_free(long_output);
+
 }
 END_TEST
 
 START_TEST(retention_data_for_services_long_output)
 {
 
-	const char *long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
+	char *long_output = g_strescape("This is a long \n plugin output \n of some sort \n and such \n", "");
 
 	svc->long_plugin_output = strdup(long_output);
 
@@ -104,6 +106,8 @@ START_TEST(retention_data_for_services_long_output)
 
 	ck_assert(OK == read_initial_state_information());
 	ck_assert_str_eq(svc->long_plugin_output, long_output);
+
+	g_free(long_output);
 
 }
 END_TEST

--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -46,28 +46,6 @@ void setup(void)
 	init_objects_host(1);
 	init_objects_service(2);
 	init_objects_command(1);
-	initialize_downtime_data();
-	initialize_comment_data();
-	initialize_retention_data();
-	workdir = getcwd(NULL, 0);
-
-	ret = asprintf(&log_file, "%s/active.log", workdir);
-	ck_assert(ret >= 0);
-
-	debug_level = -1;
-	debug_verbosity = 10;
-	debug_file = log_file;
-
-
-	/* Don't check return value, just make -Wno-unused-result happy */
-	workdir = getcwd(NULL, 0);
-
-	ret = asprintf(&log_file, "%s/active.log", workdir);
-	ck_assert(ret >= 0);
-
-	debug_level = -1;
-	debug_verbosity = 10;
-	debug_file = log_file;
 
 	cmd = create_command("my_command", "/bin/true");
 	ck_assert(cmd != NULL);
@@ -76,7 +54,7 @@ void setup(void)
 	hst = create_host(TARGET_HOST_NAME);
 	ck_assert(hst != NULL);
 	hst->check_command_ptr = cmd;
-	hst->check_command = nm_strdup("something or other");;
+	hst->check_command = nm_strdup("something or other");
 	register_host(hst);
 
 	svc = create_service(hst, TARGET_SERVICE_NAME);
@@ -89,17 +67,32 @@ void setup(void)
 	svc1->check_command_ptr = cmd;
 	register_service(svc1);
 
+	initialize_downtime_data();
+	initialize_comment_data();
+	initialize_retention_data();
+
+	workdir = getcwd(NULL, 0);
+	ck_assert(workdir != NULL);
+
+	ret = asprintf(&log_file, "%s/active.log", workdir);
+	ck_assert(ret >= 0);
+	free(workdir);
+
+	debug_level = -1;
+	debug_verbosity = 10;
+	debug_file = log_file;
+
 }
 
 void teardown(void)
 {
 
+	destroy_event_queue();
 	destroy_objects_command();
 	destroy_objects_service(TRUE);
 	destroy_objects_host();
 	cleanup_retention_data();
 	cleanup_downtime_data();
-	destroy_event_queue();
 	free(log_file);
 }
 
@@ -692,7 +685,7 @@ START_TEST(service_flexible_scheduled_downtimes_service_down_notification)
 	scheduled_downtime *dt = NULL;
 	struct check_result cr ;
 	char active_contents[1024];
-	size_t len;
+	ssize_t len;
 
 	/* fill the check_result struct for the service check failure */
 	cr.object_check_type = SERVICE_CHECK;
@@ -734,7 +727,9 @@ START_TEST(service_flexible_scheduled_downtimes_service_down_notification)
 	close_debug_log();
 
 	fd = open(log_file, O_RDONLY);
-	len = read(fd, active_contents, 1024);
+	ck_assert(fd >= 0);
+	len = read(fd, active_contents, sizeof(active_contents) - 1);
+	ck_assert(len >= 0);
 	active_contents[len] = '\0';
 	close(fd);
 	unlink(log_file);
@@ -767,7 +762,7 @@ START_TEST(host_flexible_scheduled_downtimes_service_down_notification)
 	scheduled_downtime *dt = NULL;
 	struct check_result cr ;
 	char active_contents[1024];
-	size_t len;
+	ssize_t len;
 
 	cr.object_check_type = HOST_CHECK;
 	cr.host_name = TARGET_HOST_NAME;
@@ -809,7 +804,9 @@ START_TEST(host_flexible_scheduled_downtimes_service_down_notification)
 	close_debug_log();
 
 	fd = open(log_file, O_RDONLY);
-	len = read(fd, active_contents, 1024);
+	ck_assert(fd >= 0);
+	len = read(fd, active_contents, sizeof(active_contents) - 1);
+	ck_assert(len >= 0);
 	active_contents[len] = '\0';
 	close(fd);
 	unlink(log_file);

--- a/tests/test-scheduled-downtimes.c
+++ b/tests/test-scheduled-downtimes.c
@@ -93,6 +93,7 @@ void teardown(void)
 	destroy_objects_host();
 	cleanup_retention_data();
 	cleanup_downtime_data();
+	free_comment_data();
 	free(log_file);
 }
 

--- a/tests/test-worker.c
+++ b/tests/test-worker.c
@@ -8,6 +8,7 @@
 #include "lib/libnaemon.h"
 #include <check.h>
 #include <string.h>
+#include <unistd.h>
 
 /*
  * A note about worker tests:
@@ -279,6 +280,7 @@ void worker_test_setup(void)
 	open_debug_log();
 
 	init_iobroker();
+	nagios_pid = (int)getpid();
 	enable_timing_point = 1;
 	qh_socket_path = "/tmp/qh-socket";
 	qh_init(qh_socket_path);
@@ -312,6 +314,7 @@ void worker_test_teardown(void)
 	wproc_num_workers_online = 0;
 	wproc_num_workers_spawned = 0;
 	wproc_num_workers_desired = 0;
+	nagios_pid = 0;
 }
 
 Suite *worker_suite(void)


### PR DESCRIPTION
This PR updates the github action to use ubuntu 26 and enables testing with the
`-fsanitize=address -fno-omit-frame-pointer` cflags which reqire libasan installed.
This library (https://github.com/google/sanitizers/wiki/AddressSanitizer) reports various memory related issues, like use after free, double free, etc...

For example:

    %> ./src/naemonstats/naemonstats -h
    =================================================================
    ==41276==ERROR: AddressSanitizer: odr-violation (0x00000041b080):
      [1] size=4 'nagios_pid' src/naemonstats/naemonstats.c:35:5
      [2] size=4 'nagios_pid' src/naemon/shared.c:36:5
    These globals were registered at these points:
      [1]:
        #0 0x7fc1c4184a68 in __asan_register_globals.part.0 (/lib64/libasan.so.6+0x37a68)
        #1 0x408d34 in _sub_I_00099_1 (/src/naemon-core/src/naemonstats/.libs/lt-naemonstats+0x408d34)
        #2 0x7fc1c3ae673a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x2a73a)

      [2]:
        #0 0x7fc1c4184a68 in __asan_register_globals.part.0 (/lib64/libasan.so.6+0x37a68)
        #1 0x7fc1c3f0ac13 in _sub_I_00099_1 (/src/naemon-core/.libs/libnaemon.so.0+0x10ac13)
        #2 0x7fc1c4b4955d in call_init /usr/src/debug/glibc-2.34-275.el9_8.x86_64/elf/dl-init.c:70
        #3 0x7fc1c4b4955d in call_init /usr/src/debug/glibc-2.34-275.el9_8.x86_64/elf/dl-init.c:26

    ==41276==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
    SUMMARY: AddressSanitizer: odr-violation: global 'nagios_pid' at src/naemonstats/naemonstats.c:35:5
    ==41276==ABORTING

Most of the findings are in our test suite and not related to normal runtime. Others belong to rare error paths. Anyway, i'd say all parts of naemon should run without memory errors.